### PR TITLE
fix: correct oracle comment label from scrvUSD/USD to scrvUSD/crvUSD

### DIFF
--- a/config/networks/fraxtal_mainnet.ts
+++ b/config/networks/fraxtal_mainnet.ts
@@ -363,7 +363,7 @@ export async function getConfig(
           },
           [TOKEN_INFO.scrvUSD.address]: {
             feedAsset: TOKEN_INFO.scrvUSD.address,
-            proxy1: "0x029c150a79526bEE6D3Db1b10C07C4CfA6b12485", // scrvUSD/USD dTrinity OEV
+            proxy1: "0x029c150a79526bEE6D3Db1b10C07C4CfA6b12485", // scrvUSD/crvUSD dTrinity OEV
             proxy2: "0x21234f61bFc55a586D7c28CC1776da35f9936246", // crvUSD/USD (generic, not dTrinity OEV)
             // Don't allow scrvUSD to go above $1
             lowerThresholdInBase1: 0n,


### PR DESCRIPTION
Fixes #8

Correct the incorrect comment label for the scrvUSD oracle proxy1. The comment should indicate scrvUSD/crvUSD since this is a composite oracle that uses scrvUSD/crvUSD for proxy1 and crvUSD/USD for proxy2.

Generated with [Claude Code](https://claude.ai/code)