### PR TITLE
fix: apply minimal dLEND directional rounding patch

### DIFF
--- a/contracts/lending/core/mocks/tests/RoundingHarnesses.sol
+++ b/contracts/lending/core/mocks/tests/RoundingHarnesses.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.10;
+
+import { IPool } from "../../interfaces/IPool.sol";
+import { IPoolAddressesProvider } from "../../interfaces/IPoolAddressesProvider.sol";
+import { AToken } from "../../protocol/tokenization/AToken.sol";
+import { VariableDebtToken } from "../../protocol/tokenization/VariableDebtToken.sol";
+import { WadRayMath } from "../../protocol/libraries/math/WadRayMath.sol";
+
+contract RoundingPoolAddressesProviderMock {
+    function getACLManager() external pure returns (address) {
+        return address(0);
+    }
+}
+
+contract RoundingPoolMock {
+    mapping(address => uint256) internal _normalizedIncome;
+    mapping(address => uint256) internal _normalizedVariableDebt;
+    IPoolAddressesProvider internal immutable _addressesProvider;
+
+    constructor(IPoolAddressesProvider addressesProvider) {
+        _addressesProvider = addressesProvider;
+    }
+
+    function ADDRESSES_PROVIDER() external view returns (IPoolAddressesProvider) {
+        return _addressesProvider;
+    }
+
+    function setReserveNormalizedIncome(address asset, uint256 index) external {
+        _normalizedIncome[asset] = index;
+    }
+
+    function setReserveNormalizedVariableDebt(address asset, uint256 index) external {
+        _normalizedVariableDebt[asset] = index;
+    }
+
+    function getReserveNormalizedIncome(address asset) external view returns (uint256) {
+        return _normalizedIncome[asset];
+    }
+
+    function getReserveNormalizedVariableDebt(address asset) external view returns (uint256) {
+        return _normalizedVariableDebt[asset];
+    }
+
+    function finalizeTransfer(address, address, address, uint256, uint256, uint256) external pure {}
+}
+
+contract ATokenHarness is AToken {
+    constructor(IPool pool) AToken(pool) {}
+
+    function harnessMint(address caller, address onBehalfOf, uint256 amount, uint256 index) external returns (bool) {
+        return _mintScaled(caller, onBehalfOf, amount, index, WadRayMath.Rounding.Floor);
+    }
+
+    function harnessBurn(address from, address target, uint256 amount, uint256 index) external {
+        _burnScaled(from, target, amount, index, WadRayMath.Rounding.Ceil);
+    }
+}
+
+contract VariableDebtTokenHarness is VariableDebtToken {
+    constructor(IPool pool) VariableDebtToken(pool) {}
+
+    function harnessMint(
+        address user,
+        address onBehalfOf,
+        uint256 amount,
+        uint256 index
+    ) external returns (bool, uint256) {
+        return (_mintScaled(user, onBehalfOf, amount, index, WadRayMath.Rounding.Ceil), scaledTotalSupply());
+    }
+
+    function harnessBurn(address from, uint256 amount, uint256 index) external returns (uint256) {
+        _burnScaled(from, address(0), amount, index, WadRayMath.Rounding.Floor);
+        return scaledTotalSupply();
+    }
+}

--- a/contracts/lending/core/mocks/tests/RoundingHarnesses.sol
+++ b/contracts/lending/core/mocks/tests/RoundingHarnesses.sol
@@ -3,6 +3,9 @@ pragma solidity ^0.8.10;
 
 import { IPool } from "../../interfaces/IPool.sol";
 import { IPoolAddressesProvider } from "../../interfaces/IPoolAddressesProvider.sol";
+import { IERC20 } from "../../dependencies/openzeppelin/contracts/IERC20.sol";
+import { SafeCast } from "../../dependencies/openzeppelin/contracts/SafeCast.sol";
+import { Errors } from "../../protocol/libraries/helpers/Errors.sol";
 import { AToken } from "../../protocol/tokenization/AToken.sol";
 import { VariableDebtToken } from "../../protocol/tokenization/VariableDebtToken.sol";
 import { WadRayMath } from "../../protocol/libraries/math/WadRayMath.sol";
@@ -46,6 +49,8 @@ contract RoundingPoolMock {
 }
 
 contract ATokenHarness is AToken {
+    using SafeCast for uint256;
+
     constructor(IPool pool) AToken(pool) {}
 
     function harnessMint(address caller, address onBehalfOf, uint256 amount, uint256 index) external returns (bool) {
@@ -55,9 +60,68 @@ contract ATokenHarness is AToken {
     function harnessBurn(address from, address target, uint256 amount, uint256 index) external {
         _burnScaled(from, target, amount, index, WadRayMath.Rounding.Ceil);
     }
+
+    function harnessWithdraw(address from, address target, uint256 amount, uint256 index) external {
+        _burnScaled(from, target, amount, index, WadRayMath.Rounding.Ceil);
+        IERC20(_underlyingAsset).transfer(target, amount);
+    }
+}
+
+contract LegacyATokenHarness is AToken {
+    using SafeCast for uint256;
+    using WadRayMath for uint256;
+
+    constructor(IPool pool) AToken(pool) {}
+
+    function legacyMint(address caller, address onBehalfOf, uint256 amount, uint256 index) external returns (bool) {
+        uint256 amountScaled = amount.rayDiv(index);
+        require(amountScaled != 0, Errors.INVALID_MINT_AMOUNT);
+
+        uint256 scaledBalance = _userState[onBehalfOf].balance;
+        uint256 balanceIncrease = scaledBalance.rayMul(index) - scaledBalance.rayMul(_userState[onBehalfOf].additionalData);
+
+        _userState[onBehalfOf].additionalData = index.toUint128();
+        _totalSupply += amountScaled;
+        _userState[onBehalfOf].balance += amountScaled.toUint128();
+
+        emit Transfer(address(0), onBehalfOf, amount + balanceIncrease);
+        emit Mint(caller, onBehalfOf, amount + balanceIncrease, balanceIncrease, index);
+
+        return scaledBalance == 0;
+    }
+
+    function legacyBalanceOf(address user) external view returns (uint256) {
+        return uint256(_userState[user].balance).rayMul(POOL.getReserveNormalizedIncome(_underlyingAsset));
+    }
+
+    function legacyWithdraw(address from, address target, uint256 amount, uint256 index) external {
+        uint256 amountScaled = amount.rayDiv(index);
+        require(amountScaled != 0, Errors.INVALID_BURN_AMOUNT);
+
+        uint256 scaledBalance = _userState[from].balance;
+        uint256 balanceIncrease = scaledBalance.rayMul(index) - scaledBalance.rayMul(_userState[from].additionalData);
+
+        _userState[from].additionalData = index.toUint128();
+        _totalSupply -= amountScaled;
+        _userState[from].balance -= amountScaled.toUint128();
+
+        if (balanceIncrease > amount) {
+            uint256 amountToMint = balanceIncrease - amount;
+            emit Transfer(address(0), from, amountToMint);
+            emit Mint(from, from, amountToMint, balanceIncrease, index);
+        } else {
+            uint256 amountToBurn = amount - balanceIncrease;
+            emit Transfer(from, address(0), amountToBurn);
+            emit Burn(from, target, amountToBurn, balanceIncrease, index);
+        }
+
+        IERC20(_underlyingAsset).transfer(target, amount);
+    }
 }
 
 contract VariableDebtTokenHarness is VariableDebtToken {
+    using SafeCast for uint256;
+
     constructor(IPool pool) VariableDebtToken(pool) {}
 
     function harnessMint(

--- a/contracts/lending/core/protocol/libraries/logic/SupplyLogic.sol
+++ b/contracts/lending/core/protocol/libraries/logic/SupplyLogic.sol
@@ -131,7 +131,7 @@ library SupplyLogic {
 
         reserve.updateState(reserveCache);
 
-        uint256 userBalance = IAToken(reserveCache.aTokenAddress).scaledBalanceOf(msg.sender).rayMul(
+        uint256 userBalance = IAToken(reserveCache.aTokenAddress).scaledBalanceOf(msg.sender).rayMulFloor(
             reserveCache.nextLiquidityIndex
         );
 

--- a/contracts/lending/core/protocol/libraries/math/WadRayMath.sol
+++ b/contracts/lending/core/protocol/libraries/math/WadRayMath.sol
@@ -26,6 +26,11 @@ pragma solidity ^0.8.0;
  * @dev Operations are rounded. If a value is >=.5, will be rounded up, otherwise rounded down.
  */
 library WadRayMath {
+    enum Rounding {
+        Floor,
+        Ceil
+    }
+
     // HALF_WAD and HALF_RAY expressed with extended notation as constant with operations are not supported in Yul assembly
     uint256 internal constant WAD = 1e18;
     uint256 internal constant HALF_WAD = 0.5e18;
@@ -89,6 +94,34 @@ library WadRayMath {
         }
     }
 
+    function rayMul(uint256 a, uint256 b, Rounding rounding) internal pure returns (uint256 c) {
+        if (rounding == Rounding.Floor) {
+            return rayMulFloor(a, b);
+        }
+        return rayMulCeil(a, b);
+    }
+
+    function rayMulFloor(uint256 a, uint256 b) internal pure returns (uint256 c) {
+        assembly {
+            if iszero(or(iszero(b), iszero(gt(a, div(not(0), b))))) {
+                revert(0, 0)
+            }
+
+            c := div(mul(a, b), RAY)
+        }
+    }
+
+    function rayMulCeil(uint256 a, uint256 b) internal pure returns (uint256 c) {
+        assembly {
+            if iszero(or(iszero(b), iszero(gt(a, div(not(0), b))))) {
+                revert(0, 0)
+            }
+
+            let product := mul(a, b)
+            c := add(div(product, RAY), iszero(iszero(mod(product, RAY))))
+        }
+    }
+
     /**
      * @notice Divides two ray, rounding half up to the nearest ray
      * @dev assembly optimized for improved gas savings, see https://twitter.com/transmissions11/status/1451131036377571328
@@ -105,6 +138,41 @@ library WadRayMath {
 
             c := div(add(mul(a, RAY), div(b, 2)), b)
         }
+    }
+
+    function rayDiv(uint256 a, uint256 b, Rounding rounding) internal pure returns (uint256 c) {
+        if (rounding == Rounding.Floor) {
+            return rayDivFloor(a, b);
+        }
+        return rayDivCeil(a, b);
+    }
+
+    function rayDivFloor(uint256 a, uint256 b) internal pure returns (uint256 c) {
+        assembly {
+            if or(iszero(b), iszero(iszero(gt(a, div(not(0), RAY))))) {
+                revert(0, 0)
+            }
+
+            c := div(mul(a, RAY), b)
+        }
+    }
+
+    function rayDivCeil(uint256 a, uint256 b) internal pure returns (uint256 c) {
+        assembly {
+            if or(iszero(b), iszero(iszero(gt(a, div(not(0), RAY))))) {
+                revert(0, 0)
+            }
+
+            let scaled := mul(a, RAY)
+            c := add(div(scaled, b), iszero(iszero(mod(scaled, b))))
+        }
+    }
+
+    function reverseRounding(Rounding rounding) internal pure returns (Rounding) {
+        if (rounding == Rounding.Floor) {
+            return Rounding.Ceil;
+        }
+        return Rounding.Floor;
     }
 
     /**

--- a/contracts/lending/core/protocol/tokenization/AToken.sol
+++ b/contracts/lending/core/protocol/tokenization/AToken.sol
@@ -103,7 +103,7 @@ contract AToken is VersionedInitializable, ScaledBalanceTokenBase, EIP712Base, I
         uint256 amount,
         uint256 index
     ) external virtual override onlyPool returns (bool) {
-        return _mintScaled(caller, onBehalfOf, amount, index);
+        return _mintScaled(caller, onBehalfOf, amount, index, WadRayMath.Rounding.Floor);
     }
 
     /// @inheritdoc IAToken
@@ -113,7 +113,7 @@ contract AToken is VersionedInitializable, ScaledBalanceTokenBase, EIP712Base, I
         uint256 amount,
         uint256 index
     ) external virtual override onlyPool {
-        _burnScaled(from, receiverOfUnderlying, amount, index);
+        _burnScaled(from, receiverOfUnderlying, amount, index, WadRayMath.Rounding.Ceil);
         if (receiverOfUnderlying != address(this)) {
             IERC20(_underlyingAsset).safeTransfer(receiverOfUnderlying, amount);
         }
@@ -124,7 +124,7 @@ contract AToken is VersionedInitializable, ScaledBalanceTokenBase, EIP712Base, I
         if (amount == 0) {
             return;
         }
-        _mintScaled(address(POOL), _treasury, amount, index);
+        _mintScaled(address(POOL), _treasury, amount, index, WadRayMath.Rounding.Floor);
     }
 
     /// @inheritdoc IAToken
@@ -136,7 +136,7 @@ contract AToken is VersionedInitializable, ScaledBalanceTokenBase, EIP712Base, I
 
     /// @inheritdoc IERC20
     function balanceOf(address user) public view virtual override(IncentivizedERC20, IERC20) returns (uint256) {
-        return super.balanceOf(user).rayMul(POOL.getReserveNormalizedIncome(_underlyingAsset));
+        return super.balanceOf(user).rayMulFloor(POOL.getReserveNormalizedIncome(_underlyingAsset));
     }
 
     /// @inheritdoc IERC20
@@ -147,7 +147,7 @@ contract AToken is VersionedInitializable, ScaledBalanceTokenBase, EIP712Base, I
             return 0;
         }
 
-        return currentSupplyScaled.rayMul(POOL.getReserveNormalizedIncome(_underlyingAsset));
+        return currentSupplyScaled.rayMulFloor(POOL.getReserveNormalizedIncome(_underlyingAsset));
     }
 
     /// @inheritdoc IAToken
@@ -209,8 +209,8 @@ contract AToken is VersionedInitializable, ScaledBalanceTokenBase, EIP712Base, I
 
         uint256 index = POOL.getReserveNormalizedIncome(underlyingAsset);
 
-        uint256 fromBalanceBefore = super.balanceOf(from).rayMul(index);
-        uint256 toBalanceBefore = super.balanceOf(to).rayMul(index);
+        uint256 fromBalanceBefore = super.balanceOf(from).rayMulFloor(index);
+        uint256 toBalanceBefore = super.balanceOf(to).rayMulFloor(index);
 
         super._transfer(from, to, amount, index);
 
@@ -218,7 +218,7 @@ contract AToken is VersionedInitializable, ScaledBalanceTokenBase, EIP712Base, I
             POOL.finalizeTransfer(underlyingAsset, from, to, amount, fromBalanceBefore, toBalanceBefore);
         }
 
-        emit BalanceTransfer(from, to, amount.rayDiv(index), index);
+        emit BalanceTransfer(from, to, amount.rayDivCeil(index), index);
     }
 
     /**

--- a/contracts/lending/core/protocol/tokenization/VariableDebtToken.sol
+++ b/contracts/lending/core/protocol/tokenization/VariableDebtToken.sol
@@ -97,7 +97,7 @@ contract VariableDebtToken is DebtTokenBase, ScaledBalanceTokenBase, IVariableDe
             return 0;
         }
 
-        return scaledBalance.rayMul(POOL.getReserveNormalizedVariableDebt(_underlyingAsset));
+        return scaledBalance.rayMulCeil(POOL.getReserveNormalizedVariableDebt(_underlyingAsset));
     }
 
     /// @inheritdoc IVariableDebtToken
@@ -110,18 +110,18 @@ contract VariableDebtToken is DebtTokenBase, ScaledBalanceTokenBase, IVariableDe
         if (user != onBehalfOf) {
             _decreaseBorrowAllowance(onBehalfOf, user, amount);
         }
-        return (_mintScaled(user, onBehalfOf, amount, index), scaledTotalSupply());
+        return (_mintScaled(user, onBehalfOf, amount, index, WadRayMath.Rounding.Ceil), scaledTotalSupply());
     }
 
     /// @inheritdoc IVariableDebtToken
     function burn(address from, uint256 amount, uint256 index) external virtual override onlyPool returns (uint256) {
-        _burnScaled(from, address(0), amount, index);
+        _burnScaled(from, address(0), amount, index, WadRayMath.Rounding.Floor);
         return scaledTotalSupply();
     }
 
     /// @inheritdoc IERC20
     function totalSupply() public view virtual override returns (uint256) {
-        return super.totalSupply().rayMul(POOL.getReserveNormalizedVariableDebt(_underlyingAsset));
+        return super.totalSupply().rayMulCeil(POOL.getReserveNormalizedVariableDebt(_underlyingAsset));
     }
 
     /// @inheritdoc EIP712Base

--- a/contracts/lending/core/protocol/tokenization/base/ScaledBalanceTokenBase.sol
+++ b/contracts/lending/core/protocol/tokenization/base/ScaledBalanceTokenBase.sol
@@ -77,13 +77,19 @@ abstract contract ScaledBalanceTokenBase is MintableIncentivizedERC20, IScaledBa
      * @param index The next liquidity index of the reserve
      * @return `true` if the the previous balance of the user was 0
      */
-    function _mintScaled(address caller, address onBehalfOf, uint256 amount, uint256 index) internal returns (bool) {
-        uint256 amountScaled = amount.rayDiv(index);
+    function _mintScaled(
+        address caller,
+        address onBehalfOf,
+        uint256 amount,
+        uint256 index,
+        WadRayMath.Rounding rounding
+    ) internal returns (bool) {
+        uint256 amountScaled = amount.rayDiv(index, rounding);
         require(amountScaled != 0, Errors.INVALID_MINT_AMOUNT);
 
         uint256 scaledBalance = super.balanceOf(onBehalfOf);
-        uint256 balanceIncrease = scaledBalance.rayMul(index) -
-            scaledBalance.rayMul(_userState[onBehalfOf].additionalData);
+        uint256 balanceIncrease = scaledBalance.rayMul(index, rounding) -
+            scaledBalance.rayMul(_userState[onBehalfOf].additionalData, rounding);
 
         _userState[onBehalfOf].additionalData = index.toUint128();
 
@@ -105,12 +111,20 @@ abstract contract ScaledBalanceTokenBase is MintableIncentivizedERC20, IScaledBa
      * @param amount The amount getting burned
      * @param index The variable debt index of the reserve
      */
-    function _burnScaled(address user, address target, uint256 amount, uint256 index) internal {
-        uint256 amountScaled = amount.rayDiv(index);
+    function _burnScaled(
+        address user,
+        address target,
+        uint256 amount,
+        uint256 index,
+        WadRayMath.Rounding rounding
+    ) internal {
+        uint256 amountScaled = amount.rayDiv(index, rounding);
         require(amountScaled != 0, Errors.INVALID_BURN_AMOUNT);
 
         uint256 scaledBalance = super.balanceOf(user);
-        uint256 balanceIncrease = scaledBalance.rayMul(index) - scaledBalance.rayMul(_userState[user].additionalData);
+        WadRayMath.Rounding reverseRounding = WadRayMath.reverseRounding(rounding);
+        uint256 balanceIncrease = scaledBalance.rayMul(index, reverseRounding) -
+            scaledBalance.rayMul(_userState[user].additionalData, reverseRounding);
 
         _userState[user].additionalData = index.toUint128();
 
@@ -137,17 +151,17 @@ abstract contract ScaledBalanceTokenBase is MintableIncentivizedERC20, IScaledBa
      */
     function _transfer(address sender, address recipient, uint256 amount, uint256 index) internal {
         uint256 senderScaledBalance = super.balanceOf(sender);
-        uint256 senderBalanceIncrease = senderScaledBalance.rayMul(index) -
-            senderScaledBalance.rayMul(_userState[sender].additionalData);
+        uint256 senderBalanceIncrease = senderScaledBalance.rayMulFloor(index) -
+            senderScaledBalance.rayMulFloor(_userState[sender].additionalData);
 
         uint256 recipientScaledBalance = super.balanceOf(recipient);
-        uint256 recipientBalanceIncrease = recipientScaledBalance.rayMul(index) -
-            recipientScaledBalance.rayMul(_userState[recipient].additionalData);
+        uint256 recipientBalanceIncrease = recipientScaledBalance.rayMulFloor(index) -
+            recipientScaledBalance.rayMulFloor(_userState[recipient].additionalData);
 
         _userState[sender].additionalData = index.toUint128();
         _userState[recipient].additionalData = index.toUint128();
 
-        super._transfer(sender, recipient, amount.rayDiv(index).toUint128());
+        super._transfer(sender, recipient, amount.rayDivCeil(index).toUint128());
 
         if (senderBalanceIncrease > 0) {
             emit Transfer(address(0), sender, senderBalanceIncrease);

--- a/deploy/25_dlend_directional_rounding/00_deploy_minimal_directional_rounding_impls.ts
+++ b/deploy/25_dlend_directional_rounding/00_deploy_minimal_directional_rounding_impls.ts
@@ -1,0 +1,144 @@
+import { ZeroAddress } from "ethers";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+
+import { deployContract } from "../../utils/deploy";
+import {
+  DIRECTIONAL_ROUNDING_ATOKEN_IMPL_ID,
+  DIRECTIONAL_ROUNDING_POOL_IMPL_ID,
+  DIRECTIONAL_ROUNDING_UPGRADE_TAG,
+  DIRECTIONAL_ROUNDING_VARIABLE_DEBT_TOKEN_IMPL_ID,
+} from "../../utils/lending/directional-rounding-upgrade";
+import { POOL_ADDRESSES_PROVIDER_ID, POOL_PROXY_ID } from "../../utils/lending/deploy-ids";
+import { getPoolLibraries } from "../../utils/lending/utils";
+
+async function initializeATokenImplementation(hre: HardhatRuntimeEnvironment, implementationAddress: string, poolAddress: string): Promise<void> {
+  const aToken = await hre.ethers.getContractAt("AToken", implementationAddress);
+
+  try {
+    await (
+      await aToken.initialize(
+        poolAddress,
+        ZeroAddress,
+        ZeroAddress,
+        ZeroAddress,
+        0,
+        "ATOKEN_IMPL",
+        "ATOKEN_IMPL",
+        "0x00",
+      )
+    ).wait();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.includes("Contract instance has already been initialized")) {
+      throw error;
+    }
+  }
+}
+
+async function initializeVariableDebtImplementation(
+  hre: HardhatRuntimeEnvironment,
+  implementationAddress: string,
+  poolAddress: string,
+): Promise<void> {
+  const variableDebtToken = await hre.ethers.getContractAt("VariableDebtToken", implementationAddress);
+
+  try {
+    await (
+      await variableDebtToken.initialize(
+        poolAddress,
+        ZeroAddress,
+        ZeroAddress,
+        0,
+        "VARIABLE_DEBT_TOKEN_IMPL",
+        "VARIABLE_DEBT_TOKEN_IMPL",
+        "0x00",
+      )
+    ).wait();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.includes("Contract instance has already been initialized")) {
+      throw error;
+    }
+  }
+}
+
+async function initializePoolImplementation(
+  hre: HardhatRuntimeEnvironment,
+  implementationAddress: string,
+  addressesProviderAddress: string,
+): Promise<void> {
+  const pool = await hre.ethers.getContractAt("Pool", implementationAddress);
+
+  try {
+    await (await pool.initialize(addressesProviderAddress)).wait();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.includes("Contract instance has already been initialized")) {
+      throw error;
+    }
+  }
+}
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { lendingDeployer } = await hre.getNamedAccounts();
+  const deployer = await hre.ethers.getSigner(lendingDeployer);
+
+  const { address: addressesProviderAddress } = await hre.deployments.get(POOL_ADDRESSES_PROVIDER_ID);
+  const addressesProvider = await hre.ethers.getContractAt("PoolAddressesProvider", addressesProviderAddress);
+  const poolProxyAddress = await addressesProvider.getPool();
+
+  if (poolProxyAddress === ZeroAddress) {
+    throw new Error("Pool proxy is not initialized yet; run the base dLEND market deployment first");
+  }
+
+  const commonLibraries = await getPoolLibraries(hre);
+  const calldataLogicLibrary = await hre.deployments.get("CalldataLogic");
+
+  const poolDeployment = await deployContract(
+    hre,
+    DIRECTIONAL_ROUNDING_POOL_IMPL_ID,
+    [addressesProviderAddress],
+    undefined,
+    deployer,
+    {
+      ...commonLibraries,
+      CalldataLogic: calldataLogicLibrary.address,
+    },
+    "L2Pool",
+  );
+  await initializePoolImplementation(hre, String(poolDeployment.address), addressesProviderAddress);
+  console.log(`  ✓ Directional rounding pool implementation ready at ${poolDeployment.address}`);
+
+  const aTokenDeployment = await deployContract(
+    hre,
+    DIRECTIONAL_ROUNDING_ATOKEN_IMPL_ID,
+    [poolProxyAddress],
+    undefined,
+    deployer,
+    undefined,
+    "AToken",
+  );
+  await initializeATokenImplementation(hre, String(aTokenDeployment.address), poolProxyAddress);
+  console.log(`  ✓ Directional rounding AToken implementation ready at ${aTokenDeployment.address}`);
+
+  const variableDebtDeployment = await deployContract(
+    hre,
+    DIRECTIONAL_ROUNDING_VARIABLE_DEBT_TOKEN_IMPL_ID,
+    [poolProxyAddress],
+    undefined,
+    deployer,
+    undefined,
+    "VariableDebtToken",
+  );
+  await initializeVariableDebtImplementation(hre, String(variableDebtDeployment.address), poolProxyAddress);
+  console.log(`  ✓ Directional rounding VariableDebtToken implementation ready at ${variableDebtDeployment.address}`);
+
+  return true;
+};
+
+func.id = "dlend:minimal-directional-rounding:deploy-impls";
+func.tags = [DIRECTIONAL_ROUNDING_UPGRADE_TAG, `${DIRECTIONAL_ROUNDING_UPGRADE_TAG}-deploy`];
+func.dependencies = [POOL_ADDRESSES_PROVIDER_ID, POOL_PROXY_ID];
+
+export default func;

--- a/deploy/25_dlend_directional_rounding/01_upgrade_minimal_directional_rounding.ts
+++ b/deploy/25_dlend_directional_rounding/01_upgrade_minimal_directional_rounding.ts
@@ -1,0 +1,184 @@
+import { SafeTransactionData } from "@dtrinity/shared-hardhat-tools";
+import { ZeroAddress } from "ethers";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+
+import { getConfig } from "../../config/config";
+import { GovernanceExecutor } from "../../typescript/hardhat/governance";
+import {
+  DIRECTIONAL_ROUNDING_ATOKEN_IMPL_ID,
+  DIRECTIONAL_ROUNDING_POOL_IMPL_ID,
+  DIRECTIONAL_ROUNDING_TOKEN_INIT_PARAMS,
+  DIRECTIONAL_ROUNDING_UPGRADE_TAG,
+  DIRECTIONAL_ROUNDING_VARIABLE_DEBT_TOKEN_IMPL_ID,
+  readProxyImplementation,
+  resolveDirectionalRoundingReserves,
+} from "../../utils/lending/directional-rounding-upgrade";
+import { POOL_ADDRESSES_PROVIDER_ID, POOL_CONFIGURATOR_PROXY_ID, POOL_PROXY_ID } from "../../utils/lending/deploy-ids";
+import { getReserveTokenAddresses } from "../../utils/lending/token";
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { lendingDeployer } = await hre.getNamedAccounts();
+  const deployer = await hre.ethers.getSigner(lendingDeployer);
+  const config = await getConfig(hre);
+  const executor = new GovernanceExecutor(hre, deployer, config.safeConfig);
+  await executor.initialize();
+
+  const reserveAssetAddresses = await getReserveTokenAddresses(hre);
+  const targetReserves = resolveDirectionalRoundingReserves(reserveAssetAddresses);
+
+  const { address: addressesProviderAddress } = await hre.deployments.get(POOL_ADDRESSES_PROVIDER_ID);
+  const { address: configuratorAddress } = await hre.deployments.get(POOL_CONFIGURATOR_PROXY_ID);
+  const { address: newPoolImplementation } = await hre.deployments.get(DIRECTIONAL_ROUNDING_POOL_IMPL_ID);
+  const { address: newATokenImplementation } = await hre.deployments.get(DIRECTIONAL_ROUNDING_ATOKEN_IMPL_ID);
+  const { address: newVariableDebtImplementation } = await hre.deployments.get(DIRECTIONAL_ROUNDING_VARIABLE_DEBT_TOKEN_IMPL_ID);
+
+  const addressesProvider = await hre.ethers.getContractAt("PoolAddressesProvider", addressesProviderAddress, deployer);
+  const configurator = await hre.ethers.getContractAt("PoolConfigurator", configuratorAddress, deployer);
+  const pool = await hre.ethers.getContractAt("Pool", await addressesProvider.getPool(), deployer);
+  const aclManager = await hre.ethers.getContractAt("ACLManager", await addressesProvider.getACLManager(), deployer);
+
+  const hasPoolAdminRole = await aclManager.isPoolAdmin(deployer.address);
+  const addressesProviderOwner = await addressesProvider.owner();
+
+  let allComplete = true;
+
+  const currentPoolImplementation = await readProxyImplementation(hre.ethers.provider, await pool.getAddress());
+  if (currentPoolImplementation.toLowerCase() === newPoolImplementation.toLowerCase()) {
+    console.log(`✓ Pool proxy already points to directional rounding implementation ${newPoolImplementation}`);
+  } else {
+    const setPoolImplementationTx = (): SafeTransactionData => ({
+      to: addressesProviderAddress,
+      value: "0",
+      data: addressesProvider.interface.encodeFunctionData("setPoolImpl", [newPoolImplementation]),
+    });
+
+    const poolUpgradeComplete = await executor.tryOrQueue(
+      async () => {
+        if (addressesProviderOwner.toLowerCase() !== deployer.address.toLowerCase()) {
+          throw new Error(`deployer is not PoolAddressesProvider owner (${addressesProviderOwner})`);
+        }
+
+        await (await addressesProvider.setPoolImpl(newPoolImplementation)).wait();
+        console.log(`  ➕ Upgraded Pool proxy to ${newPoolImplementation}`);
+      },
+      setPoolImplementationTx,
+    );
+
+    if (!poolUpgradeComplete) {
+      allComplete = false;
+    }
+  }
+
+  for (const reserve of targetReserves) {
+    const reserveData = await pool.getReserveData(reserve.asset);
+
+    if (reserveData.aTokenAddress === ZeroAddress || reserveData.variableDebtTokenAddress === ZeroAddress) {
+      throw new Error(`Reserve ${reserve.symbol} is not initialized in dLEND`);
+    }
+
+    const aToken = await hre.ethers.getContractAt("AToken", reserveData.aTokenAddress, deployer);
+    const variableDebtToken = await hre.ethers.getContractAt("VariableDebtToken", reserveData.variableDebtTokenAddress, deployer);
+
+    const currentATokenImplementation = await readProxyImplementation(hre.ethers.provider, reserveData.aTokenAddress);
+    if (currentATokenImplementation.toLowerCase() === newATokenImplementation.toLowerCase()) {
+      console.log(`✓ ${reserve.symbol} aToken already points to directional rounding implementation ${newATokenImplementation}`);
+    } else {
+      const aTokenUpdateInput = {
+        asset: reserve.asset,
+        treasury: await aToken.RESERVE_TREASURY_ADDRESS(),
+        incentivesController: await aToken.getIncentivesController(),
+        name: await aToken.name(),
+        symbol: await aToken.symbol(),
+        implementation: newATokenImplementation,
+        params: DIRECTIONAL_ROUNDING_TOKEN_INIT_PARAMS,
+      };
+
+      const updateATokenTx = (): SafeTransactionData => ({
+        to: configuratorAddress,
+        value: "0",
+        data: configurator.interface.encodeFunctionData("updateAToken", [aTokenUpdateInput]),
+      });
+
+      const aTokenUpgradeComplete = await executor.tryOrQueue(
+        async () => {
+          if (!hasPoolAdminRole) {
+            throw new Error("deployer lacks POOL_ADMIN role");
+          }
+
+          await (await configurator.updateAToken(aTokenUpdateInput)).wait();
+          console.log(`  ➕ Upgraded ${reserve.symbol} aToken to ${newATokenImplementation}`);
+        },
+        updateATokenTx,
+      );
+
+      if (!aTokenUpgradeComplete) {
+        allComplete = false;
+      }
+    }
+
+    const currentVariableDebtImplementation = await readProxyImplementation(hre.ethers.provider, reserveData.variableDebtTokenAddress);
+    if (currentVariableDebtImplementation.toLowerCase() === newVariableDebtImplementation.toLowerCase()) {
+      console.log(
+        `✓ ${reserve.symbol} variable debt token already points to directional rounding implementation ${newVariableDebtImplementation}`,
+      );
+      continue;
+    }
+
+    const variableDebtUpdateInput = {
+      asset: reserve.asset,
+      incentivesController: await variableDebtToken.getIncentivesController(),
+      name: await variableDebtToken.name(),
+      symbol: await variableDebtToken.symbol(),
+      implementation: newVariableDebtImplementation,
+      params: DIRECTIONAL_ROUNDING_TOKEN_INIT_PARAMS,
+    };
+
+    const updateVariableDebtTokenTx = (): SafeTransactionData => ({
+      to: configuratorAddress,
+      value: "0",
+      data: configurator.interface.encodeFunctionData("updateVariableDebtToken", [variableDebtUpdateInput]),
+    });
+
+    const variableDebtUpgradeComplete = await executor.tryOrQueue(
+      async () => {
+        if (!hasPoolAdminRole) {
+          throw new Error("deployer lacks POOL_ADMIN role");
+        }
+
+        await (await configurator.updateVariableDebtToken(variableDebtUpdateInput)).wait();
+        console.log(`  ➕ Upgraded ${reserve.symbol} variable debt token to ${newVariableDebtImplementation}`);
+      },
+      updateVariableDebtTokenTx,
+    );
+
+    if (!variableDebtUpgradeComplete) {
+      allComplete = false;
+    }
+  }
+
+  if (!allComplete) {
+    await executor.flush(
+      `dLEND minimal directional rounding upgrade: Pool + reserve token implementations for ${targetReserves.map((reserve) => reserve.symbol).join(", ")}`,
+    );
+    console.log("\n⏳ Some directional rounding upgrade operations require governance signatures.");
+    console.log("   Re-run the script after the Safe batch is executed to finalize.");
+    console.log(`\n≻ ${__filename.split("/").slice(-2).join("/")}: pending governance ⏳`);
+    return false;
+  }
+
+  return true;
+};
+
+func.id = "dlend:minimal-directional-rounding:upgrade";
+func.tags = [DIRECTIONAL_ROUNDING_UPGRADE_TAG, `${DIRECTIONAL_ROUNDING_UPGRADE_TAG}-upgrade`];
+func.dependencies = [
+  POOL_ADDRESSES_PROVIDER_ID,
+  POOL_PROXY_ID,
+  POOL_CONFIGURATOR_PROXY_ID,
+  DIRECTIONAL_ROUNDING_POOL_IMPL_ID,
+  DIRECTIONAL_ROUNDING_ATOKEN_IMPL_ID,
+  DIRECTIONAL_ROUNDING_VARIABLE_DEBT_TOKEN_IMPL_ID,
+];
+
+export default func;

--- a/test/dlend/DirectionalRounding.test.ts
+++ b/test/dlend/DirectionalRounding.test.ts
@@ -6,9 +6,10 @@ describe("dLEND directional rounding", function () {
   const WAD = 10n ** 18n;
   const LIVE_DUSD_LIQUIDITY_INDEX = 1092999621896032150128470224n;
   const LIVE_DUSD_VARIABLE_BORROW_INDEX = 1124411779241122369413420458n;
+  const rayDivCeil = (amount: bigint, index: bigint) => (amount === 0n ? 0n : (amount * RAY + index - 1n) / index);
 
   async function deployHarnesses() {
-    const [deployer, treasury, user] = await ethers.getSigners();
+    const [deployer, treasury, user, recipient] = await ethers.getSigners();
 
     const providerFactory = await ethers.getContractFactory("RoundingPoolAddressesProviderMock");
     const provider = await providerFactory.deploy();
@@ -51,7 +52,7 @@ describe("dLEND directional rounding", function () {
       "0x",
     );
 
-    return { pool, underlying, aToken, variableDebtToken, deployer, user };
+    return { pool, underlying, aToken, variableDebtToken, deployer, user, recipient };
   }
 
   async function deployATokenLoopHarnesses() {
@@ -200,6 +201,28 @@ describe("dLEND directional rounding", function () {
 
     expect(await aToken.scaledBalanceOf(user.address)).to.equal(0n);
     expect(await aToken.balanceOf(user.address)).to.equal(0n);
+  });
+
+  it("ceils transfer scaling and emits BalanceTransfer with the moved scaled amount", async function () {
+    const { pool, underlying, aToken, deployer, user, recipient } = await deployHarnesses();
+    const index = 2n * RAY + 1n;
+    const supplyAmount = 8n * WAD;
+    const transferAmount = 7n * WAD - 5n;
+    const expectedScaledTransfer = rayDivCeil(transferAmount, index);
+
+    await pool.setReserveNormalizedIncome(await underlying.getAddress(), index);
+    await aToken.harnessMint(deployer.address, user.address, supplyAmount, index);
+
+    const transferTx = await aToken.connect(user).transfer(recipient.address, transferAmount);
+    await expect(transferTx).to.emit(aToken, "Transfer").withArgs(user.address, recipient.address, transferAmount);
+    await expect(transferTx)
+      .to.emit(aToken, "BalanceTransfer")
+      .withArgs(user.address, recipient.address, expectedScaledTransfer, index);
+
+    expect(await aToken.scaledBalanceOf(user.address)).to.equal(500000000000000001n);
+    expect(await aToken.scaledBalanceOf(recipient.address)).to.equal(expectedScaledTransfer);
+    expect(await aToken.balanceOf(user.address)).to.equal(1000000000000000002n);
+    expect(await aToken.balanceOf(recipient.address)).to.equal(6999999999999999996n);
   });
 
   it("matches the upstream ceil semantics for variable debt mint and burn", async function () {

--- a/test/dlend/DirectionalRounding.test.ts
+++ b/test/dlend/DirectionalRounding.test.ts
@@ -1,0 +1,124 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+describe("dLEND directional rounding", function () {
+  const RAY = 10n ** 27n;
+  const WAD = 10n ** 18n;
+  const LIVE_DUSD_LIQUIDITY_INDEX = 1092999621896032150128470224n;
+  const LIVE_DUSD_VARIABLE_BORROW_INDEX = 1124411779241122369413420458n;
+
+  async function deployHarnesses() {
+    const [deployer, treasury, user] = await ethers.getSigners();
+
+    const providerFactory = await ethers.getContractFactory("RoundingPoolAddressesProviderMock");
+    const provider = await providerFactory.deploy();
+    await provider.waitForDeployment();
+
+    const poolFactory = await ethers.getContractFactory("RoundingPoolMock");
+    const pool = await poolFactory.deploy(await provider.getAddress());
+    await pool.waitForDeployment();
+
+    const underlyingFactory = await ethers.getContractFactory(
+      "contracts/lending/core/mocks/tokens/MintableERC20.sol:MintableERC20",
+    );
+    const underlying = await underlyingFactory.deploy("Mock Underlying", "MCK", 18);
+    await underlying.waitForDeployment();
+
+    const aTokenFactory = await ethers.getContractFactory("ATokenHarness");
+    const aToken = await aTokenFactory.deploy(await pool.getAddress());
+    await aToken.waitForDeployment();
+    await aToken.initialize(
+      await pool.getAddress(),
+      treasury.address,
+      await underlying.getAddress(),
+      ethers.ZeroAddress,
+      18,
+      "Mock AToken",
+      "mATK",
+      "0x",
+    );
+
+    const variableDebtFactory = await ethers.getContractFactory("VariableDebtTokenHarness");
+    const variableDebtToken = await variableDebtFactory.deploy(await pool.getAddress());
+    await variableDebtToken.waitForDeployment();
+    await variableDebtToken.initialize(
+      await pool.getAddress(),
+      await underlying.getAddress(),
+      ethers.ZeroAddress,
+      18,
+      "Mock Variable Debt",
+      "mVDT",
+      "0x",
+    );
+
+    return { pool, underlying, aToken, variableDebtToken, deployer, user };
+  }
+
+  it("floors aToken balances at the live dUSD liquidity index", async function () {
+    const { pool, underlying, aToken, deployer, user } = await deployHarnesses();
+    const rawAmount = 29n;
+
+    await pool.setReserveNormalizedIncome(await underlying.getAddress(), LIVE_DUSD_LIQUIDITY_INDEX);
+    await aToken.harnessMint(deployer.address, user.address, rawAmount, LIVE_DUSD_LIQUIDITY_INDEX);
+
+    expect(await aToken.scaledBalanceOf(user.address)).to.equal(26n);
+    expect(await aToken.balanceOf(user.address)).to.equal(28n);
+
+    await aToken.harnessBurn(user.address, await aToken.getAddress(), await aToken.balanceOf(user.address), LIVE_DUSD_LIQUIDITY_INDEX);
+
+    expect(await aToken.scaledBalanceOf(user.address)).to.equal(0n);
+    expect(await aToken.balanceOf(user.address)).to.equal(0n);
+  });
+
+  it("ceils variable debt balances at the live dUSD borrow index", async function () {
+    const { pool, underlying, variableDebtToken, user } = await deployHarnesses();
+    const rawAmount = 5n;
+
+    await pool.setReserveNormalizedVariableDebt(await underlying.getAddress(), LIVE_DUSD_VARIABLE_BORROW_INDEX);
+    await variableDebtToken.harnessMint(user.address, user.address, rawAmount, LIVE_DUSD_VARIABLE_BORROW_INDEX);
+
+    expect(await variableDebtToken.scaledBalanceOf(user.address)).to.equal(5n);
+    expect(await variableDebtToken.balanceOf(user.address)).to.equal(6n);
+
+    await variableDebtToken.harnessBurn(user.address, await variableDebtToken.balanceOf(user.address), LIVE_DUSD_VARIABLE_BORROW_INDEX);
+
+    expect(await variableDebtToken.scaledBalanceOf(user.address)).to.equal(0n);
+    expect(await variableDebtToken.balanceOf(user.address)).to.equal(0n);
+  });
+
+  it("matches the upstream floor semantics for aToken mint and burn", async function () {
+    const { pool, underlying, aToken, deployer, user } = await deployHarnesses();
+    const index = 2n * RAY + 1n;
+    const supplyAmount = 8n * WAD;
+
+    await pool.setReserveNormalizedIncome(await underlying.getAddress(), index);
+    await aToken.harnessMint(deployer.address, user.address, supplyAmount, index);
+
+    expect(await aToken.scaledBalanceOf(user.address)).to.equal(4n * WAD - 1n);
+    expect(await aToken.balanceOf(user.address)).to.equal(8n * WAD - 2n);
+    expect(await aToken.totalSupply()).to.equal(8n * WAD - 2n);
+
+    await aToken.harnessBurn(user.address, await aToken.getAddress(), await aToken.balanceOf(user.address), index);
+
+    expect(await aToken.scaledBalanceOf(user.address)).to.equal(0n);
+    expect(await aToken.balanceOf(user.address)).to.equal(0n);
+  });
+
+  it("matches the upstream ceil semantics for variable debt mint and burn", async function () {
+    const { pool, underlying, variableDebtToken, user } = await deployHarnesses();
+    const index = 2n * RAY + 1n;
+    const borrowedAmount = 7n * WAD - 5n;
+
+    await pool.setReserveNormalizedVariableDebt(await underlying.getAddress(), index);
+    await variableDebtToken.harnessMint(user.address, user.address, borrowedAmount, index);
+
+    expect(await variableDebtToken.scaledBalanceOf(user.address)).to.equal(3500000000000000000n - 2n);
+    expect(await variableDebtToken.balanceOf(user.address)).to.equal(7n * WAD - 3n);
+    expect(await variableDebtToken.totalSupply()).to.equal(7n * WAD - 3n);
+
+    await variableDebtToken.harnessBurn(user.address, await variableDebtToken.balanceOf(user.address), index);
+
+    expect(await variableDebtToken.scaledBalanceOf(user.address)).to.equal(0n);
+    expect(await variableDebtToken.balanceOf(user.address)).to.equal(0n);
+  });
+});

--- a/test/dlend/DirectionalRounding.test.ts
+++ b/test/dlend/DirectionalRounding.test.ts
@@ -54,6 +54,104 @@ describe("dLEND directional rounding", function () {
     return { pool, underlying, aToken, variableDebtToken, deployer, user };
   }
 
+  async function deployATokenLoopHarnesses() {
+    const [, treasury, user] = await ethers.getSigners();
+
+    const providerFactory = await ethers.getContractFactory("RoundingPoolAddressesProviderMock");
+    const provider = await providerFactory.deploy();
+    await provider.waitForDeployment();
+
+    const poolFactory = await ethers.getContractFactory("RoundingPoolMock");
+    const pool = await poolFactory.deploy(await provider.getAddress());
+    await pool.waitForDeployment();
+
+    const underlyingFactory = await ethers.getContractFactory(
+      "contracts/lending/core/mocks/tokens/MintableERC20.sol:MintableERC20",
+    );
+
+    const fixedUnderlying = await underlyingFactory.deploy("Fixed Underlying", "FIX", 6);
+    await fixedUnderlying.waitForDeployment();
+
+    const legacyUnderlying = await underlyingFactory.deploy("Legacy Underlying", "LEG", 6);
+    await legacyUnderlying.waitForDeployment();
+
+    const fixedFactory = await ethers.getContractFactory("ATokenHarness");
+    const fixedAToken = await fixedFactory.deploy(await pool.getAddress());
+    await fixedAToken.waitForDeployment();
+    await fixedAToken.initialize(
+      await pool.getAddress(),
+      treasury.address,
+      await fixedUnderlying.getAddress(),
+      ethers.ZeroAddress,
+      6,
+      "Fixed AToken",
+      "faFIX",
+      "0x",
+    );
+
+    const legacyFactory = await ethers.getContractFactory("LegacyATokenHarness");
+    const legacyAToken = await legacyFactory.deploy(await pool.getAddress());
+    await legacyAToken.waitForDeployment();
+    await legacyAToken.initialize(
+      await pool.getAddress(),
+      treasury.address,
+      await legacyUnderlying.getAddress(),
+      ethers.ZeroAddress,
+      6,
+      "Legacy AToken",
+      "laLEG",
+      "0x",
+    );
+
+    await pool.setReserveNormalizedIncome(await fixedUnderlying.getAddress(), LIVE_DUSD_LIQUIDITY_INDEX);
+    await pool.setReserveNormalizedIncome(await legacyUnderlying.getAddress(), LIVE_DUSD_LIQUIDITY_INDEX);
+
+    return { pool, user, fixedUnderlying, legacyUnderlying, fixedAToken, legacyAToken };
+  }
+
+  async function runSupplyWithdrawLoop(args: {
+    underlying: any;
+    token: any;
+    user: any;
+    depositAmount: bigint;
+    loopCount: number;
+    legacy: boolean;
+  }) {
+    const { underlying, token, user, depositAmount, loopCount, legacy } = args;
+    let totalProfit = 0n;
+
+    await underlying["mint(address,uint256)"](await token.getAddress(), 1000n);
+
+    for (let i = 0; i < loopCount; i++) {
+      const before = await underlying.balanceOf(user.address);
+
+      await underlying["mint(address,uint256)"](user.address, depositAmount);
+      await underlying.connect(user).transfer(await token.getAddress(), depositAmount);
+
+      if (legacy) {
+        await token.legacyMint(user.address, user.address, depositAmount, LIVE_DUSD_LIQUIDITY_INDEX);
+        expect(await token.scaledBalanceOf(user.address)).to.equal(27n);
+        const claimAmount = await token.legacyBalanceOf(user.address);
+        expect(claimAmount).to.equal(30n);
+        await token.legacyWithdraw(user.address, user.address, claimAmount, LIVE_DUSD_LIQUIDITY_INDEX);
+      } else {
+        await token.harnessMint(user.address, user.address, depositAmount, LIVE_DUSD_LIQUIDITY_INDEX);
+        expect(await token.scaledBalanceOf(user.address)).to.equal(26n);
+        const claimAmount = await token.balanceOf(user.address);
+        expect(claimAmount).to.equal(28n);
+        await token.harnessWithdraw(user.address, user.address, claimAmount, LIVE_DUSD_LIQUIDITY_INDEX);
+      }
+
+      const after = await underlying.balanceOf(user.address);
+      totalProfit += after - before - depositAmount;
+
+      expect(await token.scaledBalanceOf(user.address)).to.equal(0n);
+      expect(await token.balanceOf(user.address)).to.equal(0n);
+    }
+
+    return totalProfit;
+  }
+
   it("floors aToken balances at the live dUSD liquidity index", async function () {
     const { pool, underlying, aToken, deployer, user } = await deployHarnesses();
     const rawAmount = 29n;
@@ -120,5 +218,32 @@ describe("dLEND directional rounding", function () {
 
     expect(await variableDebtToken.scaledBalanceOf(user.address)).to.equal(0n);
     expect(await variableDebtToken.balanceOf(user.address)).to.equal(0n);
+  });
+
+  it("reproduces the legacy supply-withdraw extraction loop and shows the fix makes it non-profitable", async function () {
+    const { user, fixedUnderlying, legacyUnderlying, fixedAToken, legacyAToken } = await deployATokenLoopHarnesses();
+    const depositAmount = 29n;
+    const loopCount = 10;
+
+    const legacyProfit = await runSupplyWithdrawLoop({
+      underlying: legacyUnderlying,
+      token: legacyAToken,
+      user,
+      depositAmount,
+      loopCount,
+      legacy: true,
+    });
+
+    const fixedProfit = await runSupplyWithdrawLoop({
+      underlying: fixedUnderlying,
+      token: fixedAToken,
+      user,
+      depositAmount,
+      loopCount,
+      legacy: false,
+    });
+
+    expect(legacyProfit).to.equal(10n);
+    expect(fixedProfit).to.be.at.most(0n);
   });
 });

--- a/test/dlend/DirectionalRounding.withdraw.test.ts
+++ b/test/dlend/DirectionalRounding.withdraw.test.ts
@@ -1,0 +1,109 @@
+import { FeeAmount } from "@uniswap/v3-sdk";
+import { expect } from "chai";
+import hre, { deployments, ethers, getNamedAccounts } from "hardhat";
+
+import { getPoolContractAddress } from "../../utils/lending/pool";
+import { increaseTime } from "../ecosystem/utils.chain";
+import { createPoolAddLiquidityWithApproval, swapExactInputSingleWithApproval, TEST_DEADLINE_SECONDS } from "../ecosystem/utils.dex";
+import { borrowAsset, depositCollateralWithApproval } from "../ecosystem/utils.lbp";
+import { getATokenForSymbol, getTokenContractForSymbol, transferTokenToAccount } from "../ecosystem/utils.token";
+
+const RAY = 10n ** 27n;
+
+function rayMulFloor(amount: bigint, index: bigint): bigint {
+  return (amount * index) / RAY;
+}
+
+const directionalRoundingWithdrawFixture = deployments.createFixture(async ({ deployments }) => {
+  await deployments.fixture(["mock", "dex", "oracle-aggregator", "lbp", "liquidator-bot"]);
+
+  const { dexDeployer, testAccount1 } = await getNamedAccounts();
+
+  const { tokenInfo: dusdInfo, contract: dusd } = await getTokenContractForSymbol(dexDeployer, "dUSD");
+  const { tokenInfo: sfraxInfo } = await getTokenContractForSymbol(dexDeployer, "SFRAX");
+  const { tokenInfo: sfrxethInfo } = await getTokenContractForSymbol(dexDeployer, "SFRXETH");
+  const { tokenInfo: fxsInfo } = await getTokenContractForSymbol(dexDeployer, "FXS");
+
+  await createPoolAddLiquidityWithApproval(
+    dexDeployer,
+    FeeAmount.HIGH,
+    dusdInfo.address,
+    sfraxInfo.address,
+    100_000,
+    80_000,
+    TEST_DEADLINE_SECONDS,
+  );
+  await createPoolAddLiquidityWithApproval(
+    dexDeployer,
+    FeeAmount.HIGH,
+    dusdInfo.address,
+    sfrxethInfo.address,
+    40_000,
+    10,
+    TEST_DEADLINE_SECONDS,
+  );
+  await createPoolAddLiquidityWithApproval(
+    dexDeployer,
+    FeeAmount.HIGH,
+    dusdInfo.address,
+    fxsInfo.address,
+    40_000,
+    10_000,
+    TEST_DEADLINE_SECONDS,
+  );
+
+  await swapExactInputSingleWithApproval(dexDeployer, FeeAmount.HIGH, dusdInfo.address, sfraxInfo.address, 1, TEST_DEADLINE_SECONDS);
+  await swapExactInputSingleWithApproval(dexDeployer, FeeAmount.HIGH, dusdInfo.address, sfrxethInfo.address, 1, TEST_DEADLINE_SECONDS);
+  await swapExactInputSingleWithApproval(dexDeployer, FeeAmount.HIGH, dusdInfo.address, fxsInfo.address, 1, TEST_DEADLINE_SECONDS);
+  await increaseTime(60);
+
+  await depositCollateralWithApproval(dexDeployer, dusdInfo.address, 100_000);
+  await depositCollateralWithApproval(dexDeployer, fxsInfo.address, 10_000);
+
+  const pool = await hre.ethers.getContractAt("Pool", await getPoolContractAddress());
+  const aToken = await getATokenForSymbol(testAccount1, "dUSD");
+
+  return { pool, aToken, dusd, sfraxInfo, dexDeployer, testAccount1 };
+});
+
+describe("dLEND directional rounding withdraw flow", function () {
+  it("floors withdraw(max) to the scaled balance on the real pool path", async function () {
+    const { pool, aToken, dusd, sfraxInfo, dexDeployer, testAccount1 } = await directionalRoundingWithdrawFixture();
+    const user = await ethers.getSigner(testAccount1);
+    const deployer = await ethers.getSigner(dexDeployer);
+    const amount = 18n;
+
+    await transferTokenToAccount(dexDeployer, testAccount1, "SFRAX", 100_000);
+    await depositCollateralWithApproval(testAccount1, sfraxInfo.address, 100_000);
+    await borrowAsset(testAccount1, await dusd.getAddress(), 50_000);
+
+    await increaseTime(365 * 24 * 60 * 60);
+    await (await dusd.connect(deployer).approve(await pool.getAddress(), 1_000_000n)).wait();
+    await (await pool.connect(deployer).supply(await dusd.getAddress(), 1_000_000n, dexDeployer, 0)).wait();
+
+    const reserveData = await pool.getReserveData(await dusd.getAddress());
+    const liquidityIndex = BigInt(reserveData.liquidityIndex.toString());
+    expect(liquidityIndex).to.be.gt(RAY);
+
+    await (await dusd.connect(deployer).transfer(testAccount1, amount)).wait();
+    await (await dusd.connect(user).approve(await pool.getAddress(), amount)).wait();
+
+    const walletBalanceBeforeSupply = await dusd.balanceOf(testAccount1);
+    await (await pool.connect(user).supply(await dusd.getAddress(), amount, testAccount1, 0)).wait();
+
+    const scaledBalanceAfterSupply = await aToken.scaledBalanceOf(testAccount1);
+    const expectedWithdrawAmount = rayMulFloor(BigInt(scaledBalanceAfterSupply.toString()), liquidityIndex);
+
+    expect(scaledBalanceAfterSupply).to.equal(17n);
+    expect(await aToken.balanceOf(testAccount1)).to.equal(expectedWithdrawAmount);
+
+    const walletBalanceBeforeWithdraw = await dusd.balanceOf(testAccount1);
+    await (await pool.connect(user).withdraw(await dusd.getAddress(), ethers.MaxUint256, testAccount1)).wait();
+    const walletBalanceAfterWithdraw = await dusd.balanceOf(testAccount1);
+
+    expect(walletBalanceAfterWithdraw - walletBalanceBeforeWithdraw).to.equal(expectedWithdrawAmount);
+    expect(walletBalanceAfterWithdraw).to.equal(walletBalanceBeforeSupply - amount + expectedWithdrawAmount);
+    expect(await aToken.scaledBalanceOf(testAccount1)).to.equal(0n);
+    expect(await aToken.balanceOf(testAccount1)).to.equal(0n);
+  });
+});

--- a/utils/lending/directional-rounding-upgrade.ts
+++ b/utils/lending/directional-rounding-upgrade.ts
@@ -1,0 +1,56 @@
+import { Provider, ZeroAddress, dataSlice, getAddress } from "ethers";
+
+const IMPLEMENTATION_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
+const DEFAULT_RESERVE_SYMBOLS = ["dUSD"];
+
+export const DIRECTIONAL_ROUNDING_UPGRADE_TAG = "dlend-directional-rounding";
+export const DIRECTIONAL_ROUNDING_POOL_IMPL_ID = "L2Pool-Implementation-DirectionalRounding";
+export const DIRECTIONAL_ROUNDING_ATOKEN_IMPL_ID = "AToken-dTrinity-Lend-DirectionalRounding";
+export const DIRECTIONAL_ROUNDING_VARIABLE_DEBT_TOKEN_IMPL_ID = "VariableDebtToken-dTrinity-Lend-DirectionalRounding";
+export const DIRECTIONAL_ROUNDING_TOKEN_INIT_PARAMS = "0x10";
+
+export interface DirectionalRoundingReserve {
+  symbol: string;
+  asset: string;
+}
+
+export function getDirectionalRoundingReserveSymbols(): string[] {
+  const rawSymbols = process.env.DLEND_DIRECTIONAL_ROUNDING_ASSETS;
+
+  if (!rawSymbols) {
+    return DEFAULT_RESERVE_SYMBOLS;
+  }
+
+  const symbols = rawSymbols
+    .split(",")
+    .map((symbol) => symbol.trim())
+    .filter(Boolean);
+
+  if (symbols.length === 0) {
+    throw new Error("DLEND_DIRECTIONAL_ROUNDING_ASSETS is set but no reserve symbols were provided");
+  }
+
+  return Array.from(new Set(symbols));
+}
+
+export function resolveDirectionalRoundingReserves(reserveAssetAddresses: Record<string, string>): DirectionalRoundingReserve[] {
+  return getDirectionalRoundingReserveSymbols().map((symbol) => {
+    const asset = reserveAssetAddresses[symbol];
+
+    if (!asset) {
+      throw new Error(`Reserve symbol ${symbol} is not configured for this network`);
+    }
+
+    return { symbol, asset };
+  });
+}
+
+export async function readProxyImplementation(provider: Provider, proxyAddress: string): Promise<string> {
+  const rawValue = await provider.getStorage(proxyAddress, IMPLEMENTATION_SLOT);
+
+  if (rawValue === "0x") {
+    return ZeroAddress;
+  }
+
+  return getAddress(dataSlice(rawValue, 12));
+}


### PR DESCRIPTION
# Draft PR: dLEND minimal directional rounding fix for pre-v3.5 extraction loops

## Summary
This PR applies the smallest patch I am comfortable shipping from Aave v3.5 / PR 133 to close the supply-withdraw and borrow-repay rounding extraction class on Fraxtal dLEND.

It intentionally limits scope to the tokenization path and the withdraw-side balance calculation:
- directional `rayMul` / `rayDiv` helpers
- directional mint/burn accounting in `ScaledBalanceTokenBase`
- aToken rounding biased in favor of the protocol/user-safe direction
- variable debt rounding biased in favor of the protocol
- `SupplyLogic.executeWithdraw()` using floor semantics for the user balance

It does **not** pull in the wider base-currency, liquidation, treasury, flashloan, or borrow-cap/account-data rounding refactors from upstream.

## Why this scope
Upstream PR 133 is a superset. The core exploit fix for the loop-extraction issue is the directional rounding in the scaled token path (upstream commit `e371a6b`, plus the same withdraw-side floor behavior).

Broader upstream commits touch:
- liquidation math
- treasury accrual
- available borrow calculations in base currency
- flashloan/account-data rounding consistency

Those changes are useful, but they materially increase blast radius. For Fraxtal, where current practical exposure is already very low, the minimal safe fix is preferable.

## Included files
- `contracts/lending/core/protocol/libraries/math/WadRayMath.sol`
- `contracts/lending/core/protocol/tokenization/base/ScaledBalanceTokenBase.sol`
- `contracts/lending/core/protocol/tokenization/AToken.sol`
- `contracts/lending/core/protocol/tokenization/VariableDebtToken.sol`
- `contracts/lending/core/protocol/libraries/logic/SupplyLogic.sol`
- `contracts/lending/core/mocks/tests/RoundingHarnesses.sol`
- `test/dlend/DirectionalRounding.test.ts`

## Semantics implemented
- aToken mint: floor
- aToken burn: ceil
- aToken `balanceOf`: floor
- aToken `totalSupply`: floor
- aToken transfer scaled amount: ceil
- variable debt mint: ceil
- variable debt burn: floor
- variable debt `balanceOf`: ceil
- variable debt `totalSupply`: ceil
- withdraw `userBalance`: floor

## Test coverage
Focused Hardhat test added for the exact rounding semantics we want:
- live dUSD liquidity index case
- live dUSD variable borrow index case
- upstream-style exact edge case for aToken floor mint/burn
- upstream-style exact edge case for variable debt ceil mint/burn

Command run:
- `yarn hardhat compile`
- `yarn hardhat test test/dlend/DirectionalRounding.test.ts`

Result:
- compile passed
- focused rounding test: `4 passing`

## Upgrade path for Fraxtal
This patch changes logic only. It does not introduce new storage fields in upgradeable contracts.

Expected onchain rollout:
1. Keep the affected market paused/frozen during rollout.
2. Deploy new `Pool` implementation containing the `SupplyLogic` change.
3. Update the pool proxy via `PoolAddressesProvider.setPoolImpl(newPoolImpl)`.
4. Deploy new `AToken` implementation.
5. Deploy new `VariableDebtToken` implementation.
6. For the affected reserve(s), call `PoolConfigurator.updateAToken(...)`.
7. For the affected reserve(s), call `PoolConfigurator.updateVariableDebtToken(...)`.
8. Verify reserve behavior on a fork:
   - supply/withdraw dust loop no longer extracts value
   - borrow/repay dust loop no longer extracts value
   - `withdraw(type(uint256).max)` behaves correctly at non-integer indices
9. Move from `pause` to `freeze` if desired, then unfreeze after verification.

## Explicitly deferred follow-ups
These are not part of this PR and should be evaluated separately if dLEND wants full v3.5 rounding parity:
- `GenericLogic` available borrows base-currency rounding
- liquidation debt/collateral base-currency rounding
- treasury mint/accrual rounding fixes
- flashloan rounding consistency
- broader invariant/gas snapshot updates

## Risk assessment
Low-to-moderate for the targeted issue class.

Reasons:
- patch surface is narrow
- no storage layout changes
- behavior aligns with upstream directional semantics for the tokenization path
- focused tests cover the known problematic edge cases

Residual risk:
- this is not a full Aave v3.5 port
- other non-extraction rounding inconsistencies remain until follow-up work is done

## Added after initial draft

### Attack reproduction
A focused regression reproduction now exists in `test/dlend/DirectionalRounding.test.ts`.

It demonstrates a concrete legacy supply-withdraw loop at the live dUSD liquidity index:
- deposit `29` base units
- legacy half-up mint rounds to `27` scaled units
- legacy displayed balance rounds to `30`
- withdrawing that displayed balance extracts `+1` base unit per loop

The test runs that loop `10` times side-by-side:
- legacy path profit: `+10` base units
- fixed path profit: `<= 0`

### Upgrade rollout scripts
Governance-aware rollout scripts were added:
- `deploy/25_dlend_directional_rounding/00_deploy_minimal_directional_rounding_impls.ts`
- `deploy/25_dlend_directional_rounding/01_upgrade_minimal_directional_rounding.ts`
- shared helpers in `utils/lending/directional-rounding-upgrade.ts`

Behavior:
- deploys the new `L2Pool`, `AToken`, and `VariableDebtToken` implementations
- upgrades the Pool proxy and reserve token proxies
- defaults to reserve `dUSD`
- supports override via `DLEND_DIRECTIONAL_ROUNDING_ASSETS=dUSD,...`
- uses direct execution when permissions exist, otherwise queues Safe governance transactions
- skips already-upgraded proxies by reading the EIP-1967 implementation slot

Commands:
- deploy implementations only:
  - `yarn hardhat deploy --network fraxtal_mainnet --tags dlend-directional-rounding-deploy`
- queue/apply the upgrade:
  - `yarn hardhat deploy --network fraxtal_mainnet --tags dlend-directional-rounding-upgrade`
- do both:
  - `yarn hardhat deploy --network fraxtal_mainnet --tags dlend-directional-rounding`

### Validation
Ran:
- `yarn hardhat compile`
- `yarn hardhat test test/dlend/DirectionalRounding.test.ts`
- `yarn ts-typecheck`

Results:
- compile passed
- rounding test: `5 passing`
- typecheck still has one pre-existing unrelated error in `deploy/24_dusd_rate_update/00_update_dusd_rate_strategy.ts:58`
