### PR TITLE
chore(roles): prepare Fraxtal deployer governance migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,9 @@ remote-state/
 # Script outputs
 contract-addresses_*.md
 
+# Role automation reports
+reports/roles/
+
 # Docker image
 liquidator-bot-image/*
 # Exclude materials directory

--- a/.shared/README.md
+++ b/.shared/README.md
@@ -221,10 +221,10 @@ const success = runSlither({ network: 'mainnet', failOnHigh: true });
 
 The shared tooling now splits role/ownership hardening into focused scripts driven by a single manifest:
 
-- `scan-roles` – read-only visibility into AccessControl and Ownable exposure.
+- `scan-roles` – read-only visibility into AccessControl, Ownable, and upgradeable-proxy admin exposure.
 - `grant-default-admin` – grants `DEFAULT_ADMIN_ROLE` to governance (direct execution).
 - `revoke-roles` – prepares a Safe batch that revokes every deployer-held role.
-- `transfer-ownership` – transfers `Ownable` contracts from the deployer to governance.
+- `transfer-ownership` – transfers `Ownable` ownership and upgradeable-proxy admin (`changeAdmin`) from the deployer to governance.
 
 Version 2 manifests still auto-include every contract the deployer controls and let you opt out with exclusions or overrides. The schema is simpler—there is no renounce list or removal strategy anymore. A minimal manifest:
 
@@ -233,10 +233,12 @@ Version 2 manifests still auto-include every contract the deployer controls and 
   "version": 2,
   "deployer": "0xDeployer...",
   "governance": "0xGovernance...",
-  "autoInclude": { "ownable": true, "defaultAdmin": true },
+  "timelock": "0xTimelock...",
+  "autoInclude": { "ownable": true, "defaultAdmin": true, "proxyAdmin": true },
   "defaults": {
-    "ownable": { "newOwner": "{{governance}}" },
-    "defaultAdmin": { "newAdmin": "{{governance}}" }
+    "ownable": { "newOwner": "{{timelock}}" },
+    "defaultAdmin": { "newAdmin": "{{timelock}}" },
+    "proxyAdmin": { "newAdmin": "{{timelock}}" }
   },
   "safe": {
     "safeAddress": "0xSafe...",
@@ -259,12 +261,14 @@ Version 2 manifests still auto-include every contract the deployer controls and 
 }
 ```
 
-- `{{deployer}}` and `{{governance}}` placeholders resolve to the manifest addresses.
+- `{{deployer}}`, `{{governance}}`, and `{{timelock}}` placeholders resolve to the manifest addresses.
+- Optional `timelock` marks the OpenZeppelin `TimelockController` (or equivalent). Scans treat owners/admins held by the Safe **or** timelock as governed; `transfer-ownership` skips contracts already on either.
 - `autoInclude` determines the default sweep; exclusions and overrides explicitly change the plan.
-- `ownable.execution` must stay `direct`; Safe batches cannot call `transferOwnership`.
+- `ownable.execution` and `proxyAdmin.execution` must stay `direct`; Safe batches cannot call `transferOwnership` or `changeAdmin`.
+- Proxy admin is read from the Aave/dLEND `ADMIN_SLOT` storage layout (deployments exposing `changeAdmin(address)`).
 - The revoke script always generates `revokeRole` calls that the governance Safe executes offline.
 
-Before running the CLI, add `roles.deployer` and `roles.governance` to your Hardhat network config. The shared scripts fall back to these values when the CLI flags are omitted, and refuse to run if neither source is provided.
+Before running the CLI, add `roles.deployer` and `roles.governance` (and optionally `roles.timelock`) to your Hardhat network config. The shared scripts fall back to these values when the CLI flags are omitted, and refuse to run if neither deployer nor governance source is provided.
 
 Usage:
 
@@ -278,7 +282,7 @@ ts-node .shared/scripts/roles/grant-default-admin.ts --manifest manifests/roles.
 # Queue Safe revokeRole transactions for every deployer-held role
 ts-node .shared/scripts/roles/revoke-roles.ts --manifest manifests/roles.mainnet.json --network mainnet
 
-# Transfer Ownable contracts directly (prompted unless --yes)
+# Transfer Ownable ownership and proxy admin directly (prompted unless --yes)
 ts-node .shared/scripts/roles/transfer-ownership.ts --manifest manifests/roles.mainnet.json --network mainnet
 
 # Add --dry-run to any script to print the plan without sending transactions

--- a/.shared/lib/roles/governance-targets.ts
+++ b/.shared/lib/roles/governance-targets.ts
@@ -1,0 +1,34 @@
+import { getAddress } from "@ethersproject/address";
+
+export interface GovernanceTargets {
+  readonly deployer: string;
+  readonly governance: string;
+  readonly timelock?: string;
+}
+
+export function resolveGovernanceTargets(targets: GovernanceTargets): GovernanceTargets {
+  return {
+    deployer: getAddress(targets.deployer),
+    governance: getAddress(targets.governance),
+    timelock: targets.timelock ? getAddress(targets.timelock) : undefined,
+  };
+}
+
+export function isGovernedHolder(holder: string, targets: GovernanceTargets): boolean {
+  const lower = holder.toLowerCase();
+  if (lower === targets.governance.toLowerCase()) {
+    return true;
+  }
+  if (targets.timelock && lower === targets.timelock.toLowerCase()) {
+    return true;
+  }
+  return false;
+}
+
+export function matchesGovernance(address: string, targets: GovernanceTargets): boolean {
+  return address.toLowerCase() === targets.governance.toLowerCase();
+}
+
+export function matchesTimelock(address: string, targets: GovernanceTargets): boolean {
+  return Boolean(targets.timelock && address.toLowerCase() === targets.timelock.toLowerCase());
+}

--- a/.shared/lib/roles/manifest.ts
+++ b/.shared/lib/roles/manifest.ts
@@ -17,9 +17,15 @@ export interface ManifestDefaultAdminDefaults {
   readonly grantExecution?: ExecutionMode;
 }
 
+export interface ManifestProxyAdminDefaults {
+  readonly newAdmin?: string;
+  readonly execution?: ExecutionMode;
+}
+
 export interface ManifestDefaults {
   readonly ownable?: ManifestOwnableDefaults;
   readonly defaultAdmin?: ManifestDefaultAdminDefaults;
+  readonly proxyAdmin?: ManifestProxyAdminDefaults;
 }
 
 export interface ManifestOwnableOverrides extends ManifestOwnableDefaults {
@@ -30,12 +36,17 @@ export interface ManifestDefaultAdminOverrides extends ManifestDefaultAdminDefau
   readonly enabled?: boolean;
 }
 
+export interface ManifestProxyAdminOverrides extends ManifestProxyAdminDefaults {
+  readonly enabled?: boolean;
+}
+
 export interface ManifestContractOverride {
   readonly deployment: string;
   readonly alias?: string;
   readonly notes?: string;
   readonly ownable?: ManifestOwnableOverrides;
   readonly defaultAdmin?: ManifestDefaultAdminOverrides;
+  readonly proxyAdmin?: ManifestProxyAdminOverrides;
   readonly disabled?: boolean;
 }
 
@@ -50,6 +61,7 @@ export interface ManifestSafeConfig extends SafeConfig {
 export interface ManifestAutoIncludeConfig {
   readonly ownable?: boolean;
   readonly defaultAdmin?: boolean;
+  readonly proxyAdmin?: boolean;
 }
 
 export interface ManifestExclusionConfig {
@@ -59,6 +71,7 @@ export interface ManifestExclusionConfig {
   readonly reason?: string;
   readonly ownable?: boolean;
   readonly defaultAdmin?: boolean;
+  readonly proxyAdmin?: boolean;
 }
 
 export interface RoleManifest {
@@ -66,6 +79,8 @@ export interface RoleManifest {
   readonly network?: string;
   readonly deployer: string;
   readonly governance: string;
+  /** OpenZeppelin TimelockController (or equivalent) that executes delayed governance actions. */
+  readonly timelock?: string;
   readonly defaults?: ManifestDefaults;
   readonly autoInclude?: ManifestAutoIncludeConfig;
   readonly exclusions?: ManifestExclusionConfig[];
@@ -84,6 +99,11 @@ export interface ResolvedDefaultAdminAction {
   readonly grantExecution: ExecutionMode;
 }
 
+export interface ResolvedProxyAdminAction {
+  readonly newAdmin: string;
+  readonly execution: ExecutionMode;
+}
+
 export interface ResolvedOwnableOverride {
   readonly enabled?: boolean;
   readonly action?: ResolvedOwnableAction;
@@ -94,23 +114,31 @@ export interface ResolvedDefaultAdminOverride {
   readonly action?: ResolvedDefaultAdminAction;
 }
 
+export interface ResolvedProxyAdminOverride {
+  readonly enabled?: boolean;
+  readonly action?: ResolvedProxyAdminAction;
+}
+
 export interface ResolvedContractOverride {
   readonly deployment: string;
   readonly alias?: string;
   readonly notes?: string;
   readonly ownable?: ResolvedOwnableOverride;
   readonly defaultAdmin?: ResolvedDefaultAdminOverride;
+  readonly proxyAdmin?: ResolvedProxyAdminOverride;
   readonly disabled?: boolean;
 }
 
 export interface ResolvedManifestDefaults {
   readonly ownable: ResolvedOwnableAction;
   readonly defaultAdmin: ResolvedDefaultAdminAction;
+  readonly proxyAdmin: ResolvedProxyAdminAction;
 }
 
 export interface ResolvedAutoIncludeConfig {
   readonly ownable: boolean;
   readonly defaultAdmin: boolean;
+  readonly proxyAdmin: boolean;
 }
 
 export interface ResolvedExclusion {
@@ -120,6 +148,7 @@ export interface ResolvedExclusion {
   readonly reason?: string;
   readonly ownable: boolean;
   readonly defaultAdmin: boolean;
+  readonly proxyAdmin: boolean;
 }
 
 export interface ResolvedRoleManifest {
@@ -127,6 +156,7 @@ export interface ResolvedRoleManifest {
   readonly network?: string;
   readonly deployer: string;
   readonly governance: string;
+  readonly timelock?: string;
   readonly defaults: ResolvedManifestDefaults;
   readonly autoInclude: ResolvedAutoIncludeConfig;
   readonly exclusions: ResolvedExclusion[];
@@ -145,6 +175,7 @@ export class ManifestValidationError extends Error {
 interface AddressContext {
   readonly deployer: string;
   readonly governance: string;
+  readonly timelock?: string;
 }
 
 function resolveAddress(value: string | undefined, context: AddressContext, field: string): string {
@@ -160,6 +191,15 @@ function resolveAddress(value: string | undefined, context: AddressContext, fiel
 
   if (trimmed === "{{governance}}") {
     return context.governance;
+  }
+
+  if (trimmed === "{{timelock}}") {
+    if (!context.timelock) {
+      throw new ManifestValidationError(
+        "{{timelock}} was used but manifest.timelock is not set. Add timelock or use an explicit address.",
+      );
+    }
+    return context.timelock;
   }
 
   try {
@@ -198,6 +238,16 @@ export function loadRoleManifest(manifestPath: string): RoleManifest {
   }
 }
 
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+const BURN_ADDRESSES = new Set([
+  ZERO_ADDRESS.toLowerCase(),
+  "0x000000000000000000000000000000000000dead",
+]);
+
+function isPlaceholderOrBurnAddress(address: string): boolean {
+  return BURN_ADDRESSES.has(address.toLowerCase());
+}
+
 export function resolveRoleManifest(manifest: RoleManifest): ResolvedRoleManifest {
   if (manifest.version !== 2) {
     throw new ManifestValidationError(`Unsupported manifest version: ${manifest.version}`);
@@ -205,11 +255,30 @@ export function resolveRoleManifest(manifest: RoleManifest): ResolvedRoleManifes
 
   const deployer = getAddress(manifest.deployer);
   const governance = getAddress(manifest.governance);
-  const context: AddressContext = { deployer, governance };
+
+  if (isPlaceholderOrBurnAddress(deployer)) {
+    throw new ManifestValidationError(
+      `deployer cannot be a zero/burn address: ${deployer}. Update the manifest with the actual deployer wallet.`,
+    );
+  }
+
+  if (isPlaceholderOrBurnAddress(governance)) {
+    throw new ManifestValidationError(
+      `governance cannot be a zero/burn address: ${governance}. Update the manifest with the actual governance multisig.`,
+    );
+  }
+
+  const timelock = manifest.timelock?.trim() ? getAddress(manifest.timelock.trim()) : undefined;
+  if (timelock && isPlaceholderOrBurnAddress(timelock)) {
+    throw new ManifestValidationError(`timelock cannot be a zero/burn address: ${timelock}`);
+  }
+
+  const context: AddressContext = { deployer, governance, timelock };
 
   const autoInclude: ResolvedAutoIncludeConfig = {
     ownable: manifest.autoInclude?.ownable ?? true,
     defaultAdmin: manifest.autoInclude?.defaultAdmin ?? true,
+    proxyAdmin: manifest.autoInclude?.proxyAdmin ?? true,
   };
 
   const defaults = resolveManifestDefaults(manifest.defaults, context);
@@ -228,6 +297,7 @@ export function resolveRoleManifest(manifest: RoleManifest): ResolvedRoleManifes
       reason: exclusion.reason?.trim(),
       ownable: exclusion.ownable ?? true,
       defaultAdmin: exclusion.defaultAdmin ?? true,
+      proxyAdmin: exclusion.proxyAdmin ?? true,
     } satisfies ResolvedExclusion;
   });
 
@@ -260,12 +330,17 @@ export function resolveRoleManifest(manifest: RoleManifest): ResolvedRoleManifes
       ? resolveDefaultAdminOverride(contract.defaultAdmin, defaults.defaultAdmin, context, `overrides[${index}]`)
       : undefined;
 
+    const proxyAdminOverride = contract.proxyAdmin
+      ? resolveProxyAdminOverride(contract.proxyAdmin, defaults.proxyAdmin, context, `overrides[${index}]`)
+      : undefined;
+
     const resolvedOverride: ResolvedContractOverride = {
       deployment,
       ...(contract.alias && contract.alias.trim().length > 0 ? { alias: contract.alias.trim() } : {}),
       ...(contract.notes ? { notes: contract.notes } : {}),
       ...(ownableOverride ? { ownable: ownableOverride } : {}),
       ...(defaultAdminOverride ? { defaultAdmin: defaultAdminOverride } : {}),
+      ...(proxyAdminOverride ? { proxyAdmin: proxyAdminOverride } : {}),
     };
 
     overrides.push(resolvedOverride);
@@ -296,6 +371,7 @@ export function resolveRoleManifest(manifest: RoleManifest): ResolvedRoleManifes
     network: manifest.network,
     deployer,
     governance,
+    timelock,
     defaults,
     autoInclude,
     exclusions,
@@ -345,9 +421,27 @@ function resolveManifestDefaults(defaults: ManifestDefaults | undefined, context
     grantExecution,
   };
 
+  const proxyAdminDefaults = defaults?.proxyAdmin;
+  const proxyAdminExecution = normalizeExecution(proxyAdminDefaults?.execution, "direct");
+  if (proxyAdminExecution !== "direct") {
+    throw new ManifestValidationError(
+      `defaults.proxyAdmin.execution must be 'direct'. Safe execution is not supported for proxy admin transfers.`,
+    );
+  }
+
+  const resolvedProxyAdmin: ResolvedProxyAdminAction = {
+    newAdmin: resolveAddress(
+      proxyAdminDefaults?.newAdmin ?? context.governance,
+      context,
+      "defaults.proxyAdmin.newAdmin",
+    ),
+    execution: proxyAdminExecution,
+  };
+
   return {
     ownable: resolvedOwnable,
     defaultAdmin: resolvedDefaultAdmin,
+    proxyAdmin: resolvedProxyAdmin,
   };
 }
 
@@ -421,6 +515,40 @@ function resolveDefaultAdminOverride(
     action: {
       newAdmin,
       grantExecution,
+    },
+  };
+}
+
+function resolveProxyAdminOverride(
+  override: ManifestProxyAdminOverrides,
+  defaults: ResolvedProxyAdminAction,
+  context: AddressContext,
+  label: string,
+): ResolvedProxyAdminOverride {
+  const enabled = override.enabled;
+
+  if (enabled === false) {
+    return { enabled };
+  }
+
+  const execution = normalizeExecution(override.execution, defaults.execution);
+  if (execution !== "direct") {
+    throw new ManifestValidationError(
+      `${label}.proxyAdmin.execution must be 'direct'. Safe execution is not supported for proxy admin transfers.`,
+    );
+  }
+
+  const newAdmin = resolveAddress(
+    override.newAdmin ?? defaults.newAdmin,
+    context,
+    `${label}.proxyAdmin.newAdmin`,
+  );
+
+  return {
+    enabled,
+    action: {
+      newAdmin,
+      execution,
     },
   };
 }

--- a/.shared/lib/roles/planner.ts
+++ b/.shared/lib/roles/planner.ts
@@ -1,8 +1,9 @@
-import { OwnableContractInfo, RolesContractInfo } from "./scan";
+import { OwnableContractInfo, ProxyAdminContractInfo, RolesContractInfo } from "./scan";
 import {
   ResolvedContractOverride,
   ResolvedDefaultAdminAction,
   ResolvedOwnableAction,
+  ResolvedProxyAdminAction,
   ResolvedRoleManifest,
 } from "./manifest";
 
@@ -16,6 +17,8 @@ export interface PreparedContractPlan {
   readonly ownableSource?: ActionSource;
   readonly defaultAdmin?: ResolvedDefaultAdminAction;
   readonly defaultAdminSource?: ActionSource;
+  readonly proxyAdmin?: ResolvedProxyAdminAction;
+  readonly proxyAdminSource?: ActionSource;
 }
 
 interface SelectionResult<TAction> {
@@ -28,6 +31,7 @@ interface PrepareContractPlansOptions {
   readonly manifest: ResolvedRoleManifest;
   readonly rolesByDeployment: Map<string, RolesContractInfo>;
   readonly ownableByDeployment: Map<string, OwnableContractInfo>;
+  readonly proxyAdminByDeployment: Map<string, ProxyAdminContractInfo>;
 }
 
 interface OwnableSelectionOptions {
@@ -44,8 +48,15 @@ interface DefaultAdminSelectionOptions {
   readonly hasRoles: boolean;
 }
 
+interface ProxyAdminSelectionOptions {
+  readonly manifest: ResolvedRoleManifest;
+  readonly override?: ResolvedContractOverride;
+  readonly deployment: string;
+  readonly hasProxyAdmin: boolean;
+}
+
 export function prepareContractPlans(options: PrepareContractPlansOptions): PreparedContractPlan[] {
-  const { manifest, rolesByDeployment, ownableByDeployment } = options;
+  const { manifest, rolesByDeployment, ownableByDeployment, proxyAdminByDeployment } = options;
   const overrides: ResolvedContractOverride[] = Array.from(manifest.overrides ?? []);
   const overridesByDeployment: Map<string, ResolvedContractOverride> = new Map(overrides.map((o) => [o.deployment, o]));
 
@@ -53,6 +64,9 @@ export function prepareContractPlans(options: PrepareContractPlansOptions): Prep
 
   const autoCandidatesSet = new Set<string>();
   for (const deploymentName of ownableByDeployment.keys()) {
+    autoCandidatesSet.add(deploymentName);
+  }
+  for (const deploymentName of proxyAdminByDeployment.keys()) {
     autoCandidatesSet.add(deploymentName);
   }
   for (const deploymentName of rolesByDeployment.keys()) {
@@ -69,6 +83,7 @@ export function prepareContractPlans(options: PrepareContractPlansOptions): Prep
     const override: ResolvedContractOverride | undefined = overridesByDeployment.get(deployment);
     const rolesInfo = rolesByDeployment.get(deployment);
     const ownableInfo = ownableByDeployment.get(deployment);
+    const proxyAdminInfo = proxyAdminByDeployment.get(deployment);
 
     const ownableSelection = computeOwnableSelection({
       manifest,
@@ -84,7 +99,16 @@ export function prepareContractPlans(options: PrepareContractPlansOptions): Prep
       hasRoles: Boolean(rolesInfo?.defaultAdminRoleHash),
     });
 
-    const hasAction = Boolean(ownableSelection.action || defaultAdminSelection.action);
+    const proxyAdminSelection = computeProxyAdminSelection({
+      manifest,
+      override,
+      deployment,
+      hasProxyAdmin: Boolean(proxyAdminInfo),
+    });
+
+    const hasAction = Boolean(
+      ownableSelection.action || defaultAdminSelection.action || proxyAdminSelection.action,
+    );
     let hasOverride = false;
     let hasPresentation = false;
     if (override) {
@@ -104,10 +128,50 @@ export function prepareContractPlans(options: PrepareContractPlansOptions): Prep
       ownableSource: ownableSelection.source,
       defaultAdmin: defaultAdminSelection.action,
       defaultAdminSource: defaultAdminSelection.source,
+      proxyAdmin: proxyAdminSelection.action,
+      proxyAdminSource: proxyAdminSelection.source,
     });
   }
 
   return plans;
+}
+
+function computeProxyAdminSelection(
+  options: ProxyAdminSelectionOptions,
+): SelectionResult<ResolvedProxyAdminAction> {
+  const { manifest, override, deployment, hasProxyAdmin } = options;
+  const excluded = isDeploymentExcluded(manifest, deployment, "proxyAdmin");
+  const overrideConfig = override?.proxyAdmin;
+
+  if (overrideConfig && overrideConfig.enabled === false) {
+    return { excluded };
+  }
+
+  if (overrideConfig && overrideConfig.action) {
+    if (excluded && overrideConfig.enabled !== true) {
+      return { excluded: true };
+    }
+
+    return {
+      action: cloneProxyAdminAction(overrideConfig.action),
+      source: "override",
+      excluded: false,
+    };
+  }
+
+  if (excluded) {
+    return { excluded: true };
+  }
+
+  if (manifest.autoInclude.proxyAdmin && hasProxyAdmin) {
+    return {
+      action: cloneProxyAdminAction(manifest.defaults.proxyAdmin),
+      source: "auto",
+      excluded: false,
+    };
+  }
+
+  return { excluded: false };
 }
 
 function computeOwnableSelection(options: OwnableSelectionOptions): SelectionResult<ResolvedOwnableAction> {
@@ -185,7 +249,7 @@ function computeDefaultAdminSelection(options: DefaultAdminSelectionOptions): Se
 export function isDeploymentExcluded(
   manifest: ResolvedRoleManifest,
   deployment: string,
-  kind: "ownable" | "defaultAdmin",
+  kind: "ownable" | "defaultAdmin" | "proxyAdmin",
 ): boolean {
   return manifest.exclusions.some((exclusion) => {
     const appliesToKind = exclusion[kind];
@@ -216,5 +280,12 @@ export function cloneDefaultAdminAction(action: ResolvedDefaultAdminAction): Res
   return {
     newAdmin: action.newAdmin,
     grantExecution: action.grantExecution,
+  };
+}
+
+export function cloneProxyAdminAction(action: ResolvedProxyAdminAction): ResolvedProxyAdminAction {
+  return {
+    newAdmin: action.newAdmin,
+    execution: action.execution,
   };
 }

--- a/.shared/lib/roles/proxy-admin.ts
+++ b/.shared/lib/roles/proxy-admin.ts
@@ -1,0 +1,51 @@
+import { getAddress } from "@ethersproject/address";
+import { AbiItem } from "web3-utils";
+
+/**
+ * Aave / dLEND AdminUpgradeabilityProxy admin slot
+ * (keccak256("eip1967.proxy.admin") - 1 per BaseAdminUpgradeabilityProxy).
+ */
+export const AAVE_PROXY_ADMIN_SLOT = "0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103";
+
+type FunctionAbiItem = AbiItem & {
+  readonly type: "function";
+  readonly name: string;
+  readonly inputs?: { readonly type: string }[];
+};
+
+function isAbiFunctionFragment(item: AbiItem): item is FunctionAbiItem {
+  const fragment = item as { type?: string; name?: unknown };
+  return fragment.type === "function" && typeof fragment.name === "string";
+}
+
+export function detectProxyAdminFragment(abi: AbiItem[]): FunctionAbiItem | undefined {
+  return abi.find(
+    (item): item is FunctionAbiItem =>
+      isAbiFunctionFragment(item) &&
+      item.name === "changeAdmin" &&
+      (item.inputs?.length ?? 0) === 1 &&
+      item.inputs?.[0].type === "address",
+  );
+}
+
+export function parseAddressFromStorageSlot(slotValue: string): string {
+  const hex = slotValue.startsWith("0x") ? slotValue.slice(2) : slotValue;
+  const padded = hex.padStart(64, "0");
+  return getAddress(`0x${padded.slice(-40)}`);
+}
+
+export function isZeroAddress(address: string): boolean {
+  return address.toLowerCase() === "0x0000000000000000000000000000000000000000";
+}
+
+export async function readProxyAdminFromStorage(
+  provider: { getStorage: (address: string, slot: string) => Promise<string> },
+  proxyAddress: string,
+): Promise<string | null> {
+  const raw = await provider.getStorage(proxyAddress, AAVE_PROXY_ADMIN_SLOT);
+  const admin = parseAddressFromStorageSlot(raw);
+  if (isZeroAddress(admin)) {
+    return null;
+  }
+  return admin;
+}

--- a/.shared/lib/roles/scan.ts
+++ b/.shared/lib/roles/scan.ts
@@ -1,8 +1,14 @@
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { AbiItem } from "web3-utils";
 import { Interface } from "@ethersproject/abi";
+import { Logger } from "@ethersproject/logger";
 import * as fs from "fs";
 import * as path from "path";
+
+// Suppress ethers.js warnings about duplicate ABI fragment definitions.
+// This occurs when multiple contracts define the same custom error (e.g., ArrayLengthMismatch).
+// The warning is harmless but noisy when scanning many deployments.
+Logger.setLogLevel(Logger.levels.ERROR);
 
 import {
   DEFAULT_MULTICALL3_ADDRESS,
@@ -10,6 +16,8 @@ import {
   MulticallRequest,
   MulticallResult,
 } from "./multicall";
+import { detectProxyAdminFragment, readProxyAdminFromStorage } from "./proxy-admin";
+import { isGovernedHolder, matchesGovernance, matchesTimelock, resolveGovernanceTargets } from "./governance-targets";
 
 type FunctionAbiItem = AbiItem & {
   readonly type: "function";
@@ -47,7 +55,7 @@ interface RoleConstantTask {
 interface HasRoleTask {
   readonly context: RoleContractContext;
   readonly role: RoleInfo;
-  readonly holder: "deployer" | "governance";
+  readonly holder: "deployer" | "governance" | "timelock";
   readonly request: MulticallRequest;
 }
 
@@ -64,8 +72,11 @@ export interface RolesContractInfo {
   readonly roles: RoleInfo[];
   readonly rolesHeldByDeployer: RoleInfo[];
   readonly rolesHeldByGovernance: RoleInfo[];
+  readonly rolesHeldByTimelock: RoleInfo[];
   readonly defaultAdminRoleHash?: string;
   governanceHasDefaultAdmin: boolean;
+  timelockHasDefaultAdmin: boolean;
+  governedHasDefaultAdmin: boolean;
 }
 
 export interface OwnableContractInfo {
@@ -76,6 +87,20 @@ export interface OwnableContractInfo {
   readonly owner: string;
   readonly deployerIsOwner: boolean;
   readonly governanceIsOwner: boolean;
+  readonly timelockIsOwner: boolean;
+  readonly underGovernance: boolean;
+}
+
+export interface ProxyAdminContractInfo {
+  readonly deploymentName: string;
+  readonly name: string;
+  readonly address: string;
+  readonly abi: AbiItem[];
+  readonly admin: string;
+  readonly deployerIsAdmin: boolean;
+  readonly governanceIsAdmin: boolean;
+  readonly timelockIsAdmin: boolean;
+  readonly underGovernance: boolean;
 }
 
 export interface ScanTelemetry {
@@ -85,6 +110,7 @@ export interface ScanTelemetry {
   deploymentsEvaluated: number;
   rolesContractsEvaluated: number;
   ownableContractsEvaluated: number;
+  proxyAdminContractsEvaluated: number;
   multicall: {
     supported: boolean;
     batchesExecuted: number;
@@ -95,12 +121,14 @@ export interface ScanTelemetry {
     roleConstants: number;
     hasRole: number;
     owner: number;
+    proxyAdmin: number;
   };
 }
 
 export interface ScanResult {
   readonly rolesContracts: RolesContractInfo[];
   readonly ownableContracts: OwnableContractInfo[];
+  readonly proxyAdminContracts: ProxyAdminContractInfo[];
   readonly stats: ScanTelemetry;
 }
 
@@ -108,6 +136,7 @@ export interface ScanOptions {
   readonly hre: HardhatRuntimeEnvironment;
   readonly deployer: string;
   readonly governanceMultisig: string;
+  readonly timelock?: string;
   readonly deploymentsPath?: string;
   readonly logger?: (message: string) => void;
   readonly multicallAddress?: string;
@@ -172,6 +201,11 @@ async function decodeViaProvider(
 
 export async function scanRolesAndOwnership(options: ScanOptions): Promise<ScanResult> {
   const { hre, deployer, governanceMultisig, logger } = options;
+  const targets = resolveGovernanceTargets({
+    deployer,
+    governance: governanceMultisig,
+    timelock: options.timelock,
+  });
   const ethers = (hre as any).ethers;
   const network = (hre as any).network;
   const log = logger ?? (() => {});
@@ -185,6 +219,7 @@ export async function scanRolesAndOwnership(options: ScanOptions): Promise<ScanR
     deploymentsEvaluated: 0,
     rolesContractsEvaluated: 0,
     ownableContractsEvaluated: 0,
+    proxyAdminContractsEvaluated: 0,
     multicall: {
       supported: true,
       batchesExecuted: 0,
@@ -195,6 +230,7 @@ export async function scanRolesAndOwnership(options: ScanOptions): Promise<ScanR
       roleConstants: 0,
       hasRole: 0,
       owner: 0,
+      proxyAdmin: 0,
     },
   };
 
@@ -227,10 +263,12 @@ export async function scanRolesAndOwnership(options: ScanOptions): Promise<ScanR
 
   const roleContexts: RoleContractContext[] = [];
   const ownableCandidates: { summary: DeploymentSummary; fragment: FunctionAbiItem }[] = [];
+  const proxyAdminCandidates: DeploymentSummary[] = [];
 
   for (const summary of deployments) {
     const hasRoleFragment = detectHasRoleFragment(summary.abi);
     const ownableFragment = detectOwnableFragment(summary.abi);
+    const proxyAdminFragment = detectProxyAdminFragment(summary.abi);
 
     if (hasRoleFragment) {
       const roleConstantFragments = detectRoleConstantFragments(summary.abi);
@@ -246,10 +284,15 @@ export async function scanRolesAndOwnership(options: ScanOptions): Promise<ScanR
     if (ownableFragment) {
       ownableCandidates.push({ summary, fragment: ownableFragment });
     }
+
+    if (proxyAdminFragment) {
+      proxyAdminCandidates.push(summary);
+    }
   }
 
   telemetry.rolesContractsEvaluated = roleContexts.length;
   telemetry.ownableContractsEvaluated = ownableCandidates.length;
+  telemetry.proxyAdminContractsEvaluated = proxyAdminCandidates.length;
 
   const constantTasks: RoleConstantTask[] = [];
   for (const context of roleContexts) {
@@ -351,8 +394,11 @@ export async function scanRolesAndOwnership(options: ScanOptions): Promise<ScanR
       roles,
       rolesHeldByDeployer: [],
       rolesHeldByGovernance: [],
+      rolesHeldByTimelock: [],
       defaultAdminRoleHash: defaultAdmin?.hash,
       governanceHasDefaultAdmin: false,
+      timelockHasDefaultAdmin: false,
+      governedHasDefaultAdmin: false,
     };
 
     roleContracts.push(contractRecord);
@@ -376,9 +422,22 @@ export async function scanRolesAndOwnership(options: ScanOptions): Promise<ScanR
         request: {
           target: context.address,
           allowFailure: true,
-          callData: context.iface.encodeFunctionData("hasRole", [role.hash, governanceMultisig]),
+          callData: context.iface.encodeFunctionData("hasRole", [role.hash, targets.governance]),
         },
       });
+
+      if (targets.timelock) {
+        hasRoleTasks.push({
+          context,
+          role,
+          holder: "timelock",
+          request: {
+            target: context.address,
+            allowFailure: true,
+            callData: context.iface.encodeFunctionData("hasRole", [role.hash, targets.timelock]),
+          },
+        });
+      }
     }
   }
 
@@ -390,9 +449,10 @@ export async function scanRolesAndOwnership(options: ScanOptions): Promise<ScanR
   const holderSet = {
     deployer: new Map<string, Set<string>>(),
     governance: new Map<string, Set<string>>(),
+    timelock: new Map<string, Set<string>>(),
   };
 
-  const addHeldRole = (contract: RolesContractInfo, holder: "deployer" | "governance", role: RoleInfo) => {
+  const addHeldRole = (contract: RolesContractInfo, holder: HasRoleTask["holder"], role: RoleInfo) => {
     const registry = holderSet[holder];
     const key = contract.address.toLowerCase();
     const set = registry.get(key) ?? new Set<string>();
@@ -405,8 +465,10 @@ export async function scanRolesAndOwnership(options: ScanOptions): Promise<ScanR
     set.add(role.hash);
     if (holder === "deployer") {
       contract.rolesHeldByDeployer.push(role);
-    } else {
+    } else if (holder === "governance") {
       contract.rolesHeldByGovernance.push(role);
+    } else {
+      contract.rolesHeldByTimelock.push(role);
     }
   };
 
@@ -476,7 +538,14 @@ export async function scanRolesAndOwnership(options: ScanOptions): Promise<ScanR
             hre,
             task.context,
             "hasRole",
-            [task.role.hash, task.holder === "deployer" ? deployer : governanceMultisig],
+            [
+              task.role.hash,
+              task.holder === "deployer"
+                ? targets.deployer
+                : task.holder === "timelock"
+                  ? targets.timelock!
+                  : targets.governance,
+            ],
           );
 
           if (!callResult || !callResult.success) {
@@ -508,7 +577,12 @@ export async function scanRolesAndOwnership(options: ScanOptions): Promise<ScanR
     const governanceHasDefaultAdmin = contract.rolesHeldByGovernance.some(
       (role) => role.hash.toLowerCase() === defaultAdminHash.toLowerCase(),
     );
+    const timelockHasDefaultAdmin = contract.rolesHeldByTimelock.some(
+      (role) => role.hash.toLowerCase() === defaultAdminHash.toLowerCase(),
+    );
     contract.governanceHasDefaultAdmin = governanceHasDefaultAdmin;
+    contract.timelockHasDefaultAdmin = timelockHasDefaultAdmin;
+    contract.governedHasDefaultAdmin = governanceHasDefaultAdmin || timelockHasDefaultAdmin;
   }
 
   const ownableContracts: OwnableContractInfo[] = [];
@@ -529,8 +603,7 @@ export async function scanRolesAndOwnership(options: ScanOptions): Promise<ScanR
       const decoded = iface.decodeFunctionResult("owner", returnData);
       const owner = String(decoded[0]);
       const ownerLower = owner.toLowerCase();
-      const deployerLower = deployer.toLowerCase();
-      const governanceLower = governanceMultisig.toLowerCase();
+      const deployerLower = targets.deployer.toLowerCase();
       ownableContracts.push({
         deploymentName: candidate.summary.deploymentName,
         name: candidate.summary.contractName,
@@ -538,10 +611,45 @@ export async function scanRolesAndOwnership(options: ScanOptions): Promise<ScanR
         abi: candidate.summary.abi,
         owner,
         deployerIsOwner: ownerLower === deployerLower,
-        governanceIsOwner: ownerLower === governanceLower,
+        governanceIsOwner: matchesGovernance(owner, targets),
+        timelockIsOwner: matchesTimelock(owner, targets),
+        underGovernance: isGovernedHolder(owner, targets),
       });
     } catch {
       // ignore failures to read owner
+    }
+  }
+
+  const proxyAdminContracts: ProxyAdminContractInfo[] = [];
+
+  if (proxyAdminCandidates.length > 0) {
+    log(`Resolving proxy admins for ${proxyAdminCandidates.length} upgradeable proxy deployments.`);
+  }
+
+  const deployerLower = targets.deployer.toLowerCase();
+
+  for (const summary of proxyAdminCandidates) {
+    try {
+      const admin = await readProxyAdminFromStorage(ethers.provider, summary.address);
+      if (!admin) {
+        continue;
+      }
+
+      telemetry.directCalls.proxyAdmin += 1;
+      const adminLower = admin.toLowerCase();
+      proxyAdminContracts.push({
+        deploymentName: summary.deploymentName,
+        name: summary.contractName,
+        address: summary.address,
+        abi: summary.abi,
+        admin,
+        deployerIsAdmin: adminLower === deployerLower,
+        governanceIsAdmin: matchesGovernance(admin, targets),
+        timelockIsAdmin: matchesTimelock(admin, targets),
+        underGovernance: isGovernedHolder(admin, targets),
+      });
+    } catch {
+      // ignore failures to read proxy admin slot
     }
   }
 
@@ -552,6 +660,7 @@ export async function scanRolesAndOwnership(options: ScanOptions): Promise<ScanR
   return {
     rolesContracts: roleContracts,
     ownableContracts,
+    proxyAdminContracts,
     stats: telemetry,
   };
 }

--- a/.shared/lib/transactions.ts
+++ b/.shared/lib/transactions.ts
@@ -1,0 +1,34 @@
+export interface WaitForTxReceiptOptions {
+  readonly confirmations?: number;
+  readonly onRetry?: (message: string) => void;
+  readonly maxAttempts?: number;
+}
+
+/**
+ * Waits for a transaction receipt with optional retries when the RPC drops the pending tx.
+ */
+export async function waitForTxReceipt(
+  tx: { hash: string; wait: (confirmations?: number) => Promise<{ hash: string } | null> },
+  options: WaitForTxReceiptOptions = {},
+): Promise<{ hash: string } | null> {
+  const confirmations = options.confirmations ?? 1;
+  const maxAttempts = options.maxAttempts ?? 3;
+  const onRetry = options.onRetry;
+
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return await tx.wait(confirmations);
+    } catch (error) {
+      lastError = error;
+      if (attempt >= maxAttempts) {
+        break;
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      onRetry?.(`Receipt wait failed (attempt ${attempt}/${maxAttempts}): ${message}`);
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}

--- a/.shared/lib/transactions.ts
+++ b/.shared/lib/transactions.ts
@@ -1,18 +1,22 @@
+import type { ContractTransactionResponse, TransactionReceipt } from "ethers";
+
 export interface WaitForTxReceiptOptions {
   readonly confirmations?: number;
   readonly onRetry?: (message: string) => void;
   readonly maxAttempts?: number;
+  readonly timeoutMs?: number;
 }
 
 /**
- * Waits for a transaction receipt with optional retries when the RPC drops the pending tx.
+ * Waits for a transaction receipt with optional retries and hash polling when tx.wait() flakes.
  */
 export async function waitForTxReceipt(
-  tx: { hash: string; wait: (confirmations?: number) => Promise<{ hash: string } | null> },
+  tx: ContractTransactionResponse,
   options: WaitForTxReceiptOptions = {},
-): Promise<{ hash: string } | null> {
+): Promise<TransactionReceipt | null> {
   const confirmations = options.confirmations ?? 1;
   const maxAttempts = options.maxAttempts ?? 3;
+  const timeoutMs = options.timeoutMs ?? 180_000;
   const onRetry = options.onRetry;
 
   let lastError: unknown;
@@ -28,6 +32,12 @@ export async function waitForTxReceipt(
       const message = error instanceof Error ? error.message : String(error);
       onRetry?.(`Receipt wait failed (attempt ${attempt}/${maxAttempts}): ${message}`);
     }
+  }
+
+  if (tx.hash && tx.provider) {
+    const message = lastError instanceof Error ? lastError.message : String(lastError);
+    onRetry?.(`tx.wait() failed after ${maxAttempts} attempt(s) (${message}); polling receipt for ${tx.hash}...`);
+    return tx.provider.waitForTransaction(tx.hash, confirmations, timeoutMs);
   }
 
   throw lastError instanceof Error ? lastError : new Error(String(lastError));

--- a/.shared/scripts/roles/grant-default-admin.ts
+++ b/.shared/scripts/roles/grant-default-admin.ts
@@ -17,6 +17,7 @@ interface GrantTarget {
   readonly deployment: string;
   readonly contractName: string;
   readonly address: string;
+  readonly newAdmin: string;
   readonly manifestSource: ManifestSource;
   readonly defaultAdminRoleHash: string;
   readonly rolesInfo: ScanResult["rolesContracts"][number];
@@ -132,18 +133,25 @@ async function main(): Promise<void> {
       const deployerHasAdmin = rolesInfo.rolesHeldByDeployer.some(
         (role) => role.hash.toLowerCase() === defaultAdminRoleHash.toLowerCase(),
       );
-      const governedHasAdmin = rolesInfo.governedHasDefaultAdmin;
+      const targetHasAdmin = await targetHasDefaultAdmin({
+        hre,
+        manifest,
+        rolesInfo,
+        defaultAdminRoleHash,
+        newAdmin: plan.defaultAdmin.newAdmin,
+      });
 
       const target: GrantTarget = {
         deployment: plan.deployment,
         contractName,
         address,
+        newAdmin: plan.defaultAdmin.newAdmin,
         manifestSource: (plan.defaultAdminSource ?? "auto") as ManifestSource,
         defaultAdminRoleHash,
         rolesInfo,
       };
 
-      if (governedHasAdmin) {
+      if (targetHasAdmin) {
         skippedExisting.push({
           deployment: target.deployment,
           contractName,
@@ -203,16 +211,16 @@ async function main(): Promise<void> {
     logger.info(`Manifest opt-outs: ${manifestOptOuts.length}`);
 
     if (actionable.length > 0) {
-      logger.info(`\nGranting DEFAULT_ADMIN_ROLE to governance multisig ${manifest.governance}:`);
+      logger.info("\nGranting DEFAULT_ADMIN_ROLE to manifest admin targets:");
       actionable.forEach((target, index) => {
         logger.info(
-          `- [${index + 1}/${actionable.length}] ${target.contractName} (${target.address}) :: grant from deployer -> ${manifest.governance} (${target.manifestSource})`,
+          `- [${index + 1}/${actionable.length}] ${target.contractName} (${target.address}) :: grant from deployer -> ${target.newAdmin} (${target.manifestSource})`,
         );
       });
     }
 
     if (skippedExisting.length > 0) {
-      logger.info("\nAlready satisfied (governance already holds DEFAULT_ADMIN_ROLE):");
+      logger.info("\nAlready satisfied (manifest admin target already holds DEFAULT_ADMIN_ROLE):");
       skippedExisting.forEach((entry) => {
         logger.info(`- ${entry.contractName} (${entry.address}) [${entry.manifestSource}]`);
       });
@@ -240,7 +248,11 @@ async function main(): Promise<void> {
     }
 
     if (actionable.length === 0) {
-      logger.success("\nNo grants required. Governance already holds DEFAULT_ADMIN_ROLE (or manifest opts out).");
+      if (skippedNoPermission.length > 0 || skippedMissingRole.length > 0) {
+        logger.warn("\nNo grants can be sent by the deployer. Review skipped items before treating this migration as complete.");
+      } else {
+        logger.success("\nNo grants required. Manifest admin targets already hold DEFAULT_ADMIN_ROLE (or manifest opts out).");
+      }
       await maybeEmitJson(options.jsonOutput, {
         status: "no-action",
         granted: [],
@@ -274,12 +286,12 @@ async function main(): Promise<void> {
         const contract = await hre.ethers.getContractAt(target.rolesInfo.abi as any, target.address, signer);
 
         if (dryRun) {
-          logger.info("  [dry-run] Would call grantRole(DEFAULT_ADMIN_ROLE, governance)");
+          logger.info(`  [dry-run] Would call grantRole(DEFAULT_ADMIN_ROLE, ${target.newAdmin})`);
           resultsGranted.push(target);
           continue;
         }
 
-        const tx = await contract.grantRole(target.defaultAdminRoleHash, manifest.governance);
+        const tx = await contract.grantRole(target.defaultAdminRoleHash, target.newAdmin);
         const receipt = await waitForTxReceipt(tx, {
           onRetry: (message) => logger.warn(`  ${message}`),
         });
@@ -336,6 +348,32 @@ async function main(): Promise<void> {
     logger.error(String(error instanceof Error ? error.message : error));
     process.exitCode = 1;
   }
+}
+
+async function targetHasDefaultAdmin({
+  hre,
+  manifest,
+  rolesInfo,
+  defaultAdminRoleHash,
+  newAdmin,
+}: {
+  readonly hre: any;
+  readonly manifest: ReturnType<typeof resolveRoleManifest>;
+  readonly rolesInfo: ScanResult["rolesContracts"][number];
+  readonly defaultAdminRoleHash: string;
+  readonly newAdmin: string;
+}): Promise<boolean> {
+  const newAdminLower = newAdmin.toLowerCase();
+  if (newAdminLower === manifest.governance.toLowerCase()) {
+    return rolesInfo.governanceHasDefaultAdmin;
+  }
+
+  if (manifest.timelock && newAdminLower === manifest.timelock.toLowerCase()) {
+    return rolesInfo.timelockHasDefaultAdmin;
+  }
+
+  const contract = await hre.ethers.getContractAt(rolesInfo.abi as any, rolesInfo.address);
+  return Boolean(await contract.hasRole(defaultAdminRoleHash, newAdmin));
 }
 
 async function maybeEmitJson(

--- a/.shared/scripts/roles/grant-default-admin.ts
+++ b/.shared/scripts/roles/grant-default-admin.ts
@@ -4,6 +4,7 @@ import { Command } from "commander";
 import * as readline from "readline";
 
 import { logger } from "../../lib/logger";
+import { waitForTxReceipt } from "../../lib/transactions";
 import { scanRolesAndOwnership } from "../../lib/roles/scan";
 import { loadRoleManifest, resolveRoleManifest } from "../../lib/roles/manifest";
 import { prepareContractPlans, isDeploymentExcluded } from "../../lib/roles/planner";
@@ -84,6 +85,7 @@ async function main(): Promise<void> {
       hre,
       deployer: manifest.deployer,
       governanceMultisig: manifest.governance,
+      timelock: manifest.timelock,
       deploymentsPath: options.deploymentsDir,
       logger: (message: string) => logger.info(message),
     });
@@ -93,6 +95,7 @@ async function main(): Promise<void> {
       manifest,
       rolesByDeployment,
       ownableByDeployment: new Map(),
+      proxyAdminByDeployment: new Map(),
     });
 
     const actionable: GrantTarget[] = [];
@@ -129,7 +132,7 @@ async function main(): Promise<void> {
       const deployerHasAdmin = rolesInfo.rolesHeldByDeployer.some(
         (role) => role.hash.toLowerCase() === defaultAdminRoleHash.toLowerCase(),
       );
-      const governanceHasAdmin = rolesInfo.governanceHasDefaultAdmin;
+      const governedHasAdmin = rolesInfo.governedHasDefaultAdmin;
 
       const target: GrantTarget = {
         deployment: plan.deployment,
@@ -140,7 +143,7 @@ async function main(): Promise<void> {
         rolesInfo,
       };
 
-      if (governanceHasAdmin) {
+      if (governedHasAdmin) {
         skippedExisting.push({
           deployment: target.deployment,
           contractName,
@@ -277,7 +280,9 @@ async function main(): Promise<void> {
         }
 
         const tx = await contract.grantRole(target.defaultAdminRoleHash, manifest.governance);
-        const receipt = await tx.wait();
+        const receipt = await waitForTxReceipt(tx, {
+          onRetry: (message) => logger.warn(`  ${message}`),
+        });
         const txHash = receipt?.hash ?? tx.hash ?? "unknown";
         logger.info(`  ✅ Transaction hash: ${txHash}`);
         resultsGranted.push(target);

--- a/.shared/scripts/roles/revoke-roles.ts
+++ b/.shared/scripts/roles/revoke-roles.ts
@@ -73,6 +73,7 @@ async function main(): Promise<void> {
       hre,
       deployer: manifest.deployer,
       governanceMultisig: manifest.governance,
+      timelock: manifest.timelock,
       deploymentsPath: options.deploymentsDir,
       logger: (msg: string) => logger.info(msg),
     });

--- a/.shared/scripts/roles/scan-roles.ts
+++ b/.shared/scripts/roles/scan-roles.ts
@@ -7,7 +7,7 @@ import { loadRoleManifest, resolveRoleManifest, ResolvedDefaultAdminAction } fro
 import { prepareContractPlans, isDeploymentExcluded } from '../../lib/roles/planner';
 
 interface DriftIssue {
-  readonly type: 'ownable' | 'defaultAdmin';
+  readonly type: 'ownable' | 'defaultAdmin' | 'proxyAdmin';
   readonly deployment: string;
   readonly address: string;
   readonly contract: string;
@@ -17,6 +17,7 @@ interface DriftIssue {
 type ScanResult = Awaited<ReturnType<typeof scanRolesAndOwnership>>;
 type RolesExposure = ScanResult['rolesContracts'][number];
 type OwnableExposure = ScanResult['ownableContracts'][number];
+type ProxyAdminExposure = ScanResult['proxyAdminContracts'][number];
 
 async function main(): Promise<void> {
   const program = new Command();
@@ -26,6 +27,7 @@ async function main(): Promise<void> {
     .requiredOption('-n, --network <name>', 'Network to scan (must have deployments)')
     .option('-d, --deployer <address>', 'Deployer address to check for role ownership (defaults to network.config.roles.deployer)')
     .option('-g, --governance <address>', 'Governance multisig address to check (defaults to network.config.roles.governance)')
+    .option('-t, --timelock <address>', 'Timelock controller address (defaults to manifest.timelock or network.config.roles.timelock)')
     .option('--manifest <path>', 'Path to a role manifest to evaluate coverage')
     .option('--drift-check', 'Exit non-zero when deployer-held roles are not covered by the manifest')
     .option('--json-output <path>', 'Write scan report JSON to path (or stdout when set to "-")')
@@ -44,21 +46,38 @@ async function main(): Promise<void> {
     process.env.HARDHAT_NETWORK = options.network;
     const hre = require('hardhat');
 
-    const networkConfig = (hre.network?.config ?? {}) as { roles?: { deployer?: string; governance?: string } };
+    const networkConfig = (hre.network?.config ?? {}) as {
+      roles?: { deployer?: string; governance?: string; timelock?: string };
+    };
     const configRoles = networkConfig.roles ?? {};
     const deployer: string | undefined = options.deployer as string | undefined ?? configRoles.deployer;
     const governance: string | undefined = options.governance as string | undefined ?? configRoles.governance;
+    let timelock: string | undefined = options.timelock as string | undefined ?? configRoles.timelock;
 
     if (!deployer || !governance) {
       throw new Error('Missing deployer/governance addresses. Provide --deployer/--governance or set roles.deployer / roles.governance in the Hardhat network config.');
     }
 
+    if (options.manifest) {
+      const manifestForTimelock = resolveRoleManifest(loadRoleManifest(options.manifest));
+      timelock = timelock ?? manifestForTimelock.timelock;
+    }
+
+    // Warn if deployer === governance on mainnet (suspicious configuration)
+    if (deployer.toLowerCase() === governance.toLowerCase() && options.network.toLowerCase().includes('mainnet')) {
+      logger.warn(`\n⚠️  deployer === governance on mainnet network "${options.network}". Is this intentional?`);
+    }
+
     logger.info(`Scanning roles/ownership on ${options.network}`);
+    if (timelock) {
+      logger.info(`Timelock: ${timelock} (owners/admins held here count as governed)`);
+    }
 
     const result = await scanRolesAndOwnership({
       hre,
       deployer,
       governanceMultisig: governance,
+      timelock,
       deploymentsPath: options.deploymentsDir,
       logger: (m: string) => logger.info(m),
     });
@@ -66,21 +85,23 @@ async function main(): Promise<void> {
     const { stats } = result;
     const durationSeconds = (stats.durationMs / 1000).toFixed(2);
     logger.info(
-      `\nCompleted scan in ${durationSeconds}s :: deployments=${stats.deploymentsEvaluated}, rolesContracts=${stats.rolesContractsEvaluated}, ownableContracts=${stats.ownableContractsEvaluated}`,
+      `\nCompleted scan in ${durationSeconds}s :: deployments=${stats.deploymentsEvaluated}, rolesContracts=${stats.rolesContractsEvaluated}, ownableContracts=${stats.ownableContractsEvaluated}, proxyAdminContracts=${stats.proxyAdminContractsEvaluated}`,
     );
     logger.info(
       `Multicall batches=${stats.multicall.batchesExecuted}, requests=${stats.multicall.requestsAttempted}, fallbacks=${stats.multicall.fallbacks}, supported=${stats.multicall.supported}`,
     );
     logger.info(
-      `Direct calls roleHashes=${stats.directCalls.roleConstants}, hasRole=${stats.directCalls.hasRole}, owner=${stats.directCalls.owner}`,
+      `Direct calls roleHashes=${stats.directCalls.roleConstants}, hasRole=${stats.directCalls.hasRole}, owner=${stats.directCalls.owner}, proxyAdmin=${stats.directCalls.proxyAdmin}`,
     );
 
     const exposureRoles = result.rolesContracts.filter((c) => c.rolesHeldByDeployer.length > 0);
     const governanceMissingAdmin = result.rolesContracts.filter(
-      (c) => c.defaultAdminRoleHash && !c.governanceHasDefaultAdmin,
+      (c) => c.defaultAdminRoleHash && !c.governedHasDefaultAdmin,
     );
     const exposureOwnable = result.ownableContracts.filter((c) => c.deployerIsOwner);
-    const governanceOwnableMismatches = result.ownableContracts.filter((c) => !c.governanceIsOwner);
+    const governanceOwnableMismatches = result.ownableContracts.filter((c) => !c.underGovernance);
+    const exposureProxyAdmin = result.proxyAdminContracts.filter((c) => c.deployerIsAdmin);
+    const governanceProxyAdminMismatches = result.proxyAdminContracts.filter((c) => !c.underGovernance);
 
     logger.info('\nAccessControl exposures (deployer-held roles):');
     if (exposureRoles.length === 0) {
@@ -94,9 +115,9 @@ async function main(): Promise<void> {
       });
     }
 
-    logger.info('\nGovernance default admin coverage:');
+    logger.info('\nGovernance default admin coverage (Safe or timelock):');
     if (governanceMissingAdmin.length === 0) {
-      logger.success('- Governance already holds DEFAULT_ADMIN_ROLE everywhere.');
+      logger.success('- Governed party already holds DEFAULT_ADMIN_ROLE everywhere.');
     } else {
       governanceMissingAdmin.forEach((contract, index) => {
         logger.warn(`- [${index + 1}/${governanceMissingAdmin.length}] ${contract.name} (${contract.address})`);
@@ -112,13 +133,58 @@ async function main(): Promise<void> {
       });
     }
 
-    logger.info('\nOwnable contracts not yet under governance:');
+    logger.info('\nOwnable contracts not yet under governance (Safe or timelock):');
     if (governanceOwnableMismatches.length === 0) {
-      logger.success('- All Ownable contracts are governed by the multisig.');
+      logger.success('- All Ownable contracts are held by the multisig or timelock.');
     } else {
       governanceOwnableMismatches.forEach((contract, index) => {
         logger.warn(
           `- [${index + 1}/${governanceOwnableMismatches.length}] ${contract.name} (${contract.address}) owner=${contract.owner}`,
+        );
+      });
+    }
+
+    // Detect contracts owned by addresses that are neither deployer nor governance
+    // This helps catch manifest misconfigurations where the wrong deployer address is specified
+    const unknownOwners = new Map<string, number>();
+    for (const c of governanceOwnableMismatches) {
+      const owner = c.owner.toLowerCase();
+      const timelockLower = timelock?.toLowerCase();
+      if (
+        owner !== deployer.toLowerCase() &&
+        owner !== governance.toLowerCase() &&
+        (!timelockLower || owner !== timelockLower)
+      ) {
+        unknownOwners.set(c.owner, (unknownOwners.get(c.owner) || 0) + 1);
+      }
+    }
+
+    if (unknownOwners.size > 0) {
+      logger.warn('\n⚠️  Potential manifest misconfiguration detected:');
+      for (const [addr, count] of unknownOwners) {
+        logger.warn(`   ${count} contract(s) owned by ${addr} (not deployer or governance)`);
+        if (count >= 3) {
+          logger.warn(`   → Consider: Is "${addr}" the actual deployer? Update manifest if so.`);
+        }
+      }
+    }
+
+    logger.info('\nProxy admin exposures (deployer-held):');
+    if (exposureProxyAdmin.length === 0) {
+      logger.success('- Deployer is not the proxy admin of any scanned upgradeable proxies.');
+    } else {
+      exposureProxyAdmin.forEach((contract, index) => {
+        logger.info(`- [${index + 1}/${exposureProxyAdmin.length}] ${contract.name} (${contract.address})`);
+      });
+    }
+
+    logger.info('\nUpgradeable proxies not yet administered by governance (Safe or timelock):');
+    if (governanceProxyAdminMismatches.length === 0) {
+      logger.success('- Governed party is the proxy admin for all scanned upgradeable proxies.');
+    } else {
+      governanceProxyAdminMismatches.forEach((contract, index) => {
+        logger.warn(
+          `- [${index + 1}/${governanceProxyAdminMismatches.length}] ${contract.name} (${contract.address}) admin=${contract.admin}`,
         );
       });
     }
@@ -128,11 +194,28 @@ async function main(): Promise<void> {
 
     if (options.manifest) {
       manifest = resolveRoleManifest(loadRoleManifest(options.manifest));
+
+      // Warn if manifest network doesn't match the scan network
+      if (manifest.network && manifest.network !== options.network) {
+        logger.warn(
+          `\n⚠️  Network mismatch: manifest.network="${manifest.network}" but scanning "${options.network}"`,
+        );
+      }
+
       const rolesByDeployment = new Map(result.rolesContracts.map((info) => [info.deploymentName, info]));
       const ownableByDeployment = new Map(result.ownableContracts.map((info) => [info.deploymentName, info]));
-      const plans = prepareContractPlans({ manifest, rolesByDeployment, ownableByDeployment });
+      const proxyAdminByDeployment = new Map(result.proxyAdminContracts.map((info) => [info.deploymentName, info]));
+      const plans = prepareContractPlans({
+        manifest,
+        rolesByDeployment,
+        ownableByDeployment,
+        proxyAdminByDeployment,
+      });
 
       const plannedOwnable = new Set(plans.filter((plan) => Boolean(plan.ownable)).map((plan) => plan.deployment));
+      const plannedProxyAdmin = new Set(
+        plans.filter((plan) => Boolean(plan.proxyAdmin)).map((plan) => plan.deployment),
+      );
       const plannedDefaultAdmin = new Map<string, ResolvedDefaultAdminAction>();
       for (const plan of plans) {
         if (plan.defaultAdmin) {
@@ -141,6 +224,7 @@ async function main(): Promise<void> {
       }
 
       driftIssues = [...findOwnableDrift({ manifest, plannedOwnable, exposureOwnable })];
+      driftIssues.push(...findProxyAdminDrift({ manifest, plannedProxyAdmin, exposureProxyAdmin }));
       driftIssues.push(...findDefaultAdminDrift({ manifest, plannedDefaultAdmin, exposureRoles }));
 
       if (options.driftCheck) {
@@ -163,9 +247,11 @@ async function main(): Promise<void> {
         network: options.network,
         deployer,
         governance,
+        timelock: timelock ?? null,
         summary: {
           rolesContracts: result.rolesContracts.length,
           ownableContracts: result.ownableContracts.length,
+          proxyAdminContracts: result.proxyAdminContracts.length,
         },
         stats,
         exposures: {
@@ -174,6 +260,12 @@ async function main(): Promise<void> {
             address: c.address,
             contract: c.name,
             owner: c.owner,
+          })),
+          proxyAdmin: exposureProxyAdmin.map((c) => ({
+            deployment: c.deploymentName,
+            address: c.address,
+            contract: c.name,
+            admin: c.admin,
           })),
           defaultAdmin: exposureRoles.map((c) => ({
             deployment: c.deploymentName,
@@ -235,6 +327,38 @@ function findOwnableDrift({
       address: exposure.address,
       contract: exposure.name,
       detail: 'Manifest does not include an Ownable transfer for this deployment.',
+    });
+  }
+
+  return issues;
+}
+
+function findProxyAdminDrift({
+  manifest,
+  plannedProxyAdmin,
+  exposureProxyAdmin,
+}: {
+  manifest: ReturnType<typeof resolveRoleManifest>;
+  plannedProxyAdmin: Set<string>;
+  exposureProxyAdmin: ProxyAdminExposure[];
+}): DriftIssue[] {
+  const issues: DriftIssue[] = [];
+
+  for (const exposure of exposureProxyAdmin) {
+    if (plannedProxyAdmin.has(exposure.deploymentName)) {
+      continue;
+    }
+
+    if (isDeploymentExcluded(manifest, exposure.deploymentName, 'proxyAdmin')) {
+      continue;
+    }
+
+    issues.push({
+      type: 'proxyAdmin',
+      deployment: exposure.deploymentName,
+      address: exposure.address,
+      contract: exposure.name,
+      detail: 'Manifest does not include a proxy admin transfer (changeAdmin) for this deployment.',
     });
   }
 

--- a/.shared/scripts/roles/transfer-ownership.ts
+++ b/.shared/scripts/roles/transfer-ownership.ts
@@ -4,6 +4,7 @@ import { Command } from "commander";
 import * as readline from "readline";
 
 import { logger } from "../../lib/logger";
+import { waitForTxReceipt } from "../../lib/transactions";
 import { scanRolesAndOwnership } from "../../lib/roles/scan";
 import { loadRoleManifest, resolveRoleManifest } from "../../lib/roles/manifest";
 import { prepareContractPlans, isDeploymentExcluded } from "../../lib/roles/planner";
@@ -12,7 +13,8 @@ type ScanResult = Awaited<ReturnType<typeof scanRolesAndOwnership>>;
 
 type ManifestSource = "auto" | "override";
 
-interface TransferTarget {
+interface OwnableTransferTarget {
+  readonly kind: "ownable";
   readonly deployment: string;
   readonly contractName: string;
   readonly address: string;
@@ -21,6 +23,19 @@ interface TransferTarget {
   readonly manifestSource: ManifestSource;
   readonly abi: ScanResult["ownableContracts"][number]["abi"];
 }
+
+interface ProxyAdminTransferTarget {
+  readonly kind: "proxyAdmin";
+  readonly deployment: string;
+  readonly contractName: string;
+  readonly address: string;
+  readonly currentAdmin: string;
+  readonly newAdmin: string;
+  readonly manifestSource: ManifestSource;
+  readonly abi: ScanResult["proxyAdminContracts"][number]["abi"];
+}
+
+type TransferTarget = OwnableTransferTarget | ProxyAdminTransferTarget;
 
 interface ContractRef {
   readonly deployment: string;
@@ -47,7 +62,9 @@ async function main(): Promise<void> {
   const program = new Command();
 
   program
-    .description("Transfer Ownable contracts from the deployer to governance as defined in the manifest.")
+    .description(
+      "Transfer Ownable ownership and upgradeable-proxy admin from the deployer to governance as defined in the manifest.",
+    )
     .requiredOption("-m, --manifest <path>", "Path to the role manifest JSON")
     .requiredOption("-n, --network <name>", "Hardhat network to target")
     .option("--deployments-dir <path>", "Path to deployments directory (defaults to hardhat configured path)")
@@ -74,67 +91,109 @@ async function main(): Promise<void> {
       hre,
       deployer: manifest.deployer,
       governanceMultisig: manifest.governance,
+      timelock: manifest.timelock,
       deploymentsPath: options.deploymentsDir,
       logger: (msg: string) => logger.info(msg),
     });
 
     const rolesByDeployment = new Map(scan.rolesContracts.map((info) => [info.deploymentName, info]));
     const ownableByDeployment = new Map(scan.ownableContracts.map((info) => [info.deploymentName, info]));
-    const plans = prepareContractPlans({ manifest, rolesByDeployment, ownableByDeployment });
+    const proxyAdminByDeployment = new Map(scan.proxyAdminContracts.map((info) => [info.deploymentName, info]));
+    const plans = prepareContractPlans({
+      manifest,
+      rolesByDeployment,
+      ownableByDeployment,
+      proxyAdminByDeployment,
+    });
 
-    const actionable: TransferTarget[] = [];
+    const ownableActionable: OwnableTransferTarget[] = [];
+    const proxyAdminActionable: ProxyAdminTransferTarget[] = [];
     const skippedAlreadyOwned: ContractRef[] = [];
     const skippedNotOwner: ContractRef[] = [];
+    const skippedAlreadyGovernedProxy: ContractRef[] = [];
+    const skippedNotProxyAdmin: ContractRef[] = [];
     const missingOwnable: ContractRef[] = [];
+    const missingProxyAdmin: ContractRef[] = [];
     const manifestOptOuts: OptOutRef[] = [];
 
     for (const plan of plans) {
-      if (!plan.ownable) {
-        continue;
+      if (plan.ownable) {
+        const ownableInfo = ownableByDeployment.get(plan.deployment);
+        const manifestSource: ManifestSource = (plan.ownableSource ?? "auto") as ManifestSource;
+
+        if (!ownableInfo) {
+          missingOwnable.push({
+            deployment: plan.deployment,
+            contractName: plan.alias ?? plan.deployment,
+            address: "unknown",
+            manifestSource,
+          });
+        } else if (ownableInfo.underGovernance) {
+          skippedAlreadyOwned.push({
+            deployment: plan.deployment,
+            contractName: ownableInfo.name,
+            address: ownableInfo.address,
+            manifestSource,
+          });
+        } else if (!ownableInfo.deployerIsOwner) {
+          skippedNotOwner.push({
+            deployment: plan.deployment,
+            contractName: ownableInfo.name,
+            address: ownableInfo.address,
+            manifestSource,
+          });
+        } else {
+          ownableActionable.push({
+            kind: "ownable",
+            deployment: plan.deployment,
+            contractName: ownableInfo.name,
+            address: ownableInfo.address,
+            currentOwner: ownableInfo.owner,
+            newOwner: plan.ownable.newOwner,
+            manifestSource,
+            abi: ownableInfo.abi,
+          });
+        }
       }
 
-      const ownableInfo = ownableByDeployment.get(plan.deployment);
-      const manifestSource: ManifestSource = (plan.ownableSource ?? "auto") as ManifestSource;
+      if (plan.proxyAdmin) {
+        const proxyInfo = proxyAdminByDeployment.get(plan.deployment);
+        const manifestSource: ManifestSource = (plan.proxyAdminSource ?? "auto") as ManifestSource;
 
-      if (!ownableInfo) {
-        missingOwnable.push({
-          deployment: plan.deployment,
-          contractName: plan.alias ?? plan.deployment,
-          address: "unknown",
-          manifestSource,
-        });
-        continue;
+        if (!proxyInfo) {
+          missingProxyAdmin.push({
+            deployment: plan.deployment,
+            contractName: plan.alias ?? plan.deployment,
+            address: "unknown",
+            manifestSource,
+          });
+        } else if (proxyInfo.underGovernance) {
+          skippedAlreadyGovernedProxy.push({
+            deployment: plan.deployment,
+            contractName: proxyInfo.name,
+            address: proxyInfo.address,
+            manifestSource,
+          });
+        } else if (!proxyInfo.deployerIsAdmin) {
+          skippedNotProxyAdmin.push({
+            deployment: plan.deployment,
+            contractName: proxyInfo.name,
+            address: proxyInfo.address,
+            manifestSource,
+          });
+        } else {
+          proxyAdminActionable.push({
+            kind: "proxyAdmin",
+            deployment: plan.deployment,
+            contractName: proxyInfo.name,
+            address: proxyInfo.address,
+            currentAdmin: proxyInfo.admin,
+            newAdmin: plan.proxyAdmin.newAdmin,
+            manifestSource,
+            abi: proxyInfo.abi,
+          });
+        }
       }
-
-      if (ownableInfo.governanceIsOwner) {
-        skippedAlreadyOwned.push({
-          deployment: plan.deployment,
-          contractName: ownableInfo.name,
-          address: ownableInfo.address,
-          manifestSource,
-        });
-        continue;
-      }
-
-      if (!ownableInfo.deployerIsOwner) {
-        skippedNotOwner.push({
-          deployment: plan.deployment,
-          contractName: ownableInfo.name,
-          address: ownableInfo.address,
-          manifestSource,
-        });
-        continue;
-      }
-
-      actionable.push({
-        deployment: plan.deployment,
-        contractName: ownableInfo.name,
-        address: ownableInfo.address,
-        currentOwner: ownableInfo.owner,
-        newOwner: plan.ownable.newOwner,
-        manifestSource,
-        abi: ownableInfo.abi,
-      });
     }
 
     for (const ownableInfo of scan.ownableContracts) {
@@ -152,7 +211,7 @@ async function main(): Promise<void> {
           deployment: ownableInfo.deploymentName,
           contractName: ownableInfo.name,
           address: ownableInfo.address,
-          reason: "Manifest exclusion",
+          reason: "Manifest exclusion (ownable)",
         });
         continue;
       }
@@ -173,41 +232,97 @@ async function main(): Promise<void> {
           deployment: ownableInfo.deploymentName,
           contractName: ownableInfo.name,
           address: ownableInfo.address,
-          reason: "Auto-include disabled and no override present",
+          reason: "Auto-include disabled and no ownable override present",
         });
       }
     }
 
-    logger.info("\n=== Ownership Transfer Plan ===");
-    logger.info(`Pending transfers: ${actionable.length}`);
-    logger.info(`Already owned by governance: ${skippedAlreadyOwned.length}`);
+    for (const proxyInfo of scan.proxyAdminContracts) {
+      if (!proxyInfo.deployerIsAdmin) {
+        continue;
+      }
+
+      const plan = plans.find((p) => p.deployment === proxyInfo.deploymentName);
+      if (plan?.proxyAdmin) {
+        continue;
+      }
+
+      if (isDeploymentExcluded(manifest, proxyInfo.deploymentName, "proxyAdmin")) {
+        manifestOptOuts.push({
+          deployment: proxyInfo.deploymentName,
+          contractName: proxyInfo.name,
+          address: proxyInfo.address,
+          reason: "Manifest exclusion (proxyAdmin)",
+        });
+        continue;
+      }
+
+      const override = manifest.overrides.find((o) => o.deployment === proxyInfo.deploymentName);
+      if (override?.proxyAdmin?.enabled === false) {
+        manifestOptOuts.push({
+          deployment: proxyInfo.deploymentName,
+          contractName: proxyInfo.name,
+          address: proxyInfo.address,
+          reason: "Override disabled proxyAdmin actions",
+        });
+        continue;
+      }
+
+      if (!manifest.autoInclude.proxyAdmin) {
+        manifestOptOuts.push({
+          deployment: proxyInfo.deploymentName,
+          contractName: proxyInfo.name,
+          address: proxyInfo.address,
+          reason: "Auto-include disabled and no proxyAdmin override present",
+        });
+      }
+    }
+
+    const actionable: TransferTarget[] = [...ownableActionable, ...proxyAdminActionable];
+
+    logger.info("\n=== Ownership / Proxy Admin Transfer Plan ===");
+    logger.info(`Pending Ownable transfers: ${ownableActionable.length}`);
+    logger.info(`Pending proxy admin transfers: ${proxyAdminActionable.length}`);
+    logger.info(`Already owned by governance (Ownable): ${skippedAlreadyOwned.length}`);
     logger.info(`Skipped (deployer not owner): ${skippedNotOwner.length}`);
+    logger.info(`Already governed (proxy admin): ${skippedAlreadyGovernedProxy.length}`);
+    logger.info(`Skipped (deployer not proxy admin): ${skippedNotProxyAdmin.length}`);
     logger.info(`Missing Ownable metadata: ${missingOwnable.length}`);
+    logger.info(`Missing proxy admin metadata: ${missingProxyAdmin.length}`);
     logger.info(`Manifest opt-outs: ${manifestOptOuts.length}`);
 
     if (actionable.length === 0) {
-      logger.success("\nNo ownership transfers required.");
+      logger.success("\nNo ownership or proxy admin transfers required.");
       await emitJson(options.jsonOutput, {
         status: "no-action",
         executed: [],
         skippedAlreadyOwned,
         skippedNotOwner,
+        skippedAlreadyGovernedProxy,
+        skippedNotProxyAdmin,
         missingOwnable,
+        missingProxyAdmin,
         manifestOptOuts,
         failures: [],
       });
       return;
     }
 
-    logger.warn("\n⚠️ Ownership transfers are irreversible. Verify each target carefully before proceeding.");
+    logger.warn("\n⚠️ Transfers are irreversible. Verify each target carefully before proceeding.");
     actionable.forEach((item, index) => {
-      logger.info(
-        `- [${index + 1}/${actionable.length}] ${item.contractName} (${item.address}) :: owner=${item.currentOwner} -> ${item.newOwner} (${item.manifestSource})`,
-      );
+      if (item.kind === "ownable") {
+        logger.info(
+          `- [${index + 1}/${actionable.length}] ${item.contractName} (${item.address}) :: owner=${item.currentOwner} -> ${item.newOwner} (${item.manifestSource})`,
+        );
+      } else {
+        logger.info(
+          `- [${index + 1}/${actionable.length}] ${item.contractName} (${item.address}) :: proxyAdmin=${item.currentAdmin} -> ${item.newAdmin} (${item.manifestSource})`,
+        );
+      }
     });
 
     if (!dryRun && !options.yes) {
-      const confirmed = await promptYesNo("\nProceed with ownership transfers? (yes/no): ");
+      const confirmed = await promptYesNo("\nProceed with ownership / proxy admin transfers? (yes/no): ");
       if (!confirmed) {
         logger.info("Aborted by user.");
         return;
@@ -220,33 +335,69 @@ async function main(): Promise<void> {
 
     for (let index = 0; index < actionable.length; index += 1) {
       const target = actionable[index];
-      logger.info(`\n[${index + 1}/${actionable.length}] Transferring ownership of ${target.contractName} (${target.address})`);
+
+      if (target.kind === "ownable") {
+        logger.info(
+          `\n[${index + 1}/${actionable.length}] Transferring ownership of ${target.contractName} (${target.address})`,
+        );
+
+        try {
+          const contract = await hre.ethers.getContractAt(target.abi as any, target.address, signer);
+
+          if (dryRun) {
+            logger.info("  [dry-run] Would call transferOwnership(newOwner)");
+            executed.push(target);
+            continue;
+          }
+
+          const tx = await contract.transferOwnership(target.newOwner);
+          const receipt = await waitForTxReceipt(tx, {
+            onRetry: (message) => logger.warn(`  ${message}`),
+          });
+          const txHash = receipt?.hash ?? tx.hash ?? "unknown";
+          logger.info(`  ✅ Transaction hash: ${txHash}`);
+          executed.push(target);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          logger.error(`  ❌ Failed to transfer ownership: ${message}`);
+          failures.push({ target, error: message });
+        }
+        continue;
+      }
+
+      logger.info(
+        `\n[${index + 1}/${actionable.length}] Transferring proxy admin of ${target.contractName} (${target.address})`,
+      );
 
       try {
         const contract = await hre.ethers.getContractAt(target.abi as any, target.address, signer);
 
         if (dryRun) {
-          logger.info("  [dry-run] Would call transferOwnership(newOwner)");
+          logger.info("  [dry-run] Would call changeAdmin(newAdmin)");
           executed.push(target);
           continue;
         }
 
-        const tx = await contract.transferOwnership(target.newOwner);
-        const receipt = await tx.wait();
+        const tx = await contract.changeAdmin(target.newAdmin);
+        const receipt = await waitForTxReceipt(tx, {
+          onRetry: (message) => logger.warn(`  ${message}`),
+        });
         const txHash = receipt?.hash ?? tx.hash ?? "unknown";
         logger.info(`  ✅ Transaction hash: ${txHash}`);
         executed.push(target);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        logger.error(`  ❌ Failed to transfer ownership: ${message}`);
+        logger.error(`  ❌ Failed to transfer proxy admin: ${message}`);
         failures.push({ target, error: message });
       }
     }
 
     logger.info("\n=== Summary ===");
     logger.info(`Transfers executed: ${executed.length}`);
-    logger.info(`Already owned by governance: ${skippedAlreadyOwned.length}`);
+    logger.info(`Already owned by governance (Ownable): ${skippedAlreadyOwned.length}`);
     logger.info(`Skipped (deployer not owner): ${skippedNotOwner.length}`);
+    logger.info(`Already governed (proxy admin): ${skippedAlreadyGovernedProxy.length}`);
+    logger.info(`Skipped (deployer not proxy admin): ${skippedNotProxyAdmin.length}`);
     logger.info(`Manifest opt-outs: ${manifestOptOuts.length}`);
     logger.info(`Failures: ${failures.length}`);
 
@@ -269,7 +420,10 @@ async function main(): Promise<void> {
       executed,
       skippedAlreadyOwned,
       skippedNotOwner,
+      skippedAlreadyGovernedProxy,
+      skippedNotProxyAdmin,
       missingOwnable,
+      missingProxyAdmin,
       manifestOptOuts,
       failures,
     });
@@ -287,7 +441,10 @@ async function emitJson(
     executed: TransferTarget[];
     skippedAlreadyOwned: ContractRef[];
     skippedNotOwner: ContractRef[];
+    skippedAlreadyGovernedProxy: ContractRef[];
+    skippedNotProxyAdmin: ContractRef[];
     missingOwnable: ContractRef[];
+    missingProxyAdmin: ContractRef[];
     manifestOptOuts: OptOutRef[];
     failures: { target: TransferTarget; error: string }[];
   },

--- a/.shared/scripts/tests/run.ts
+++ b/.shared/scripts/tests/run.ts
@@ -10,6 +10,13 @@ import { generateNSLOCReport } from '../../lib/deployments/nsloc';
 import { loadProjectModule, getSolidityFiles } from '../../lib/utils';
 import { validateConfig } from '../../lib/validators';
 import { buildAggregatorList } from '../../lib/oracles/prices/asset-extractors';
+import {
+  detectProxyAdminFragment,
+  parseAddressFromStorageSlot,
+  isZeroAddress,
+} from '../../lib/roles/proxy-admin';
+import { isGovernedHolder, matchesTimelock } from '../../lib/roles/governance-targets';
+import { resolveRoleManifest, ManifestValidationError } from '../../lib/roles/manifest';
 
 type TestCase = {
   name: string;
@@ -61,6 +68,70 @@ test('validateConfig surfaces missing required keys and type mismatches', () => 
     ),
     'type mismatch should be reported'
   );
+});
+
+test('detectProxyAdminFragment matches changeAdmin(address) proxies', () => {
+  const abi = [
+    {
+      type: 'function',
+      name: 'changeAdmin',
+      inputs: [{ type: 'address', name: 'newAdmin' }],
+      outputs: [],
+      stateMutability: 'nonpayable',
+    },
+  ];
+
+  const fragment = detectProxyAdminFragment(abi as any);
+  assert.ok(fragment, 'changeAdmin fragment should be detected');
+  assert.equal(fragment?.name, 'changeAdmin');
+});
+
+test('isGovernedHolder accepts governance Safe or timelock', () => {
+  const targets = {
+    deployer: '0x0000000000000000000000000000000000000001',
+    governance: '0x0000000000000000000000000000000000000002',
+    timelock: '0x0000000000000000000000000000000000000003',
+  };
+  assert.equal(isGovernedHolder(targets.governance, targets), true);
+  assert.equal(isGovernedHolder(targets.timelock!, targets), true);
+  assert.equal(isGovernedHolder(targets.deployer, targets), false);
+  assert.equal(matchesTimelock(targets.timelock!, targets), true);
+});
+
+test('resolveRoleManifest resolves {{timelock}} placeholder', () => {
+  const resolved = resolveRoleManifest({
+    version: 2,
+    deployer: '0x0000000000000000000000000000000000000001',
+    governance: '0x0000000000000000000000000000000000000002',
+    timelock: '0x0000000000000000000000000000000000000003',
+    defaults: {
+      ownable: { newOwner: '{{timelock}}' },
+    },
+  });
+  assert.equal(resolved.defaults.ownable.newOwner, '0x0000000000000000000000000000000000000003');
+});
+
+test('resolveRoleManifest rejects {{timelock}} without manifest.timelock', () => {
+  assert.throws(
+    () =>
+      resolveRoleManifest({
+        version: 2,
+        deployer: '0x0000000000000000000000000000000000000001',
+        governance: '0x0000000000000000000000000000000000000002',
+        defaults: {
+          ownable: { newOwner: '{{timelock}}' },
+        },
+      }),
+    ManifestValidationError,
+  );
+});
+
+test('parseAddressFromStorageSlot extracts trailing 20 bytes', () => {
+  const deployer = '0x0f5e3D9AEe7Ab5fDa909Af1ef147D98a7f4B3022';
+  const slot =
+    '0x0000000000000000000000000f5e3d9aee7ab5fda909af1ef147d98a7f4b3022';
+  assert.equal(parseAddressFromStorageSlot(slot).toLowerCase(), deployer.toLowerCase());
+  assert.equal(isZeroAddress('0x0000000000000000000000000000000000000000'), true);
 });
 
 test('getSolidityFiles discovers Solidity sources recursively', () => {

--- a/manifests/fraxtal-mainnet-roles.json
+++ b/manifests/fraxtal-mainnet-roles.json
@@ -3,6 +3,7 @@
   "network": "fraxtal_mainnet",
   "deployer": "0x0f5e3D9AEe7Ab5fDa909Af1ef147D98a7f4B3022",
   "governance": "0xfC2f89F9982BE98A9672CEFc3Ea6dBBdd88bc8e9",
+  "timelock": "0x0bafada2a5824864720873ee40cd960b36445212",
   "defaults": {
     "ownable": {
       "newOwner": "{{governance}}",
@@ -11,13 +12,33 @@
     "defaultAdmin": {
       "newAdmin": "{{governance}}",
       "grantExecution": "direct"
+    },
+    "proxyAdmin": {
+      "newAdmin": "{{governance}}",
+      "execution": "direct"
     }
   },
   "autoInclude": {
     "ownable": true,
-    "defaultAdmin": true
+    "defaultAdmin": true,
+    "proxyAdmin": true
   },
-  "exclusions": [],
+  "exclusions": [
+    {
+      "deploymentPrefix": "FlashLoanLiquidator",
+      "reason": "Liquidator bot-owned ops contracts; do not move without ops sign-off.",
+      "ownable": true,
+      "defaultAdmin": false,
+      "proxyAdmin": false
+    },
+    {
+      "deploymentPrefix": "FlashMintLiquidator",
+      "reason": "Liquidator bot-owned ops contracts; do not move without ops sign-off.",
+      "ownable": true,
+      "defaultAdmin": false,
+      "proxyAdmin": false
+    }
+  ],
   "overrides": [],
   "safe": {
     "safeAddress": "0xfC2f89F9982BE98A9672CEFc3Ea6dBBdd88bc8e9",
@@ -30,4 +51,3 @@
     "json": "reports/roles/fraxtal-mainnet-latest.json"
   }
 }
-


### PR DESCRIPTION
## Summary

- Sync role governance tooling into `.shared`.
- Update the Fraxtal mainnet manifest with timelock metadata.
- Add proxy-admin migration defaults targeting the Fraxtal governance Safe, not the timelock.
- Exclude liquidator bot-owned Ownable contracts from drift/action planning.
- Ignore generated role automation reports.
- Sync the DEFAULT_ADMIN_ROLE grant fix that checks the manifest target specifically.

## Verification

```bash
yarn ts-node .shared/scripts/tests/run.ts
```

```bash
yarn ts-node .shared/scripts/roles/scan-roles.ts \
  --network fraxtal_mainnet \
  --manifest manifests/fraxtal-mainnet-roles.json \
  --deployer 0x0f5e3D9AEe7Ab5fDa909Af1ef147D98a7f4B3022 \
  --governance 0xfC2f89F9982BE98A9672CEFc3Ea6dBBdd88bc8e9 \
  --drift-check \
  --json-output reports/roles/fraxtal-scan-baseline.json
```

```bash
yarn ts-node .shared/scripts/roles/transfer-ownership.ts \
  --network fraxtal_mainnet \
  --manifest manifests/fraxtal-mainnet-roles.json \
  --dry-run \
  --json-output reports/roles/fraxtal-transfer-ownership-dry-run.json
```

```bash
yarn ts-node .shared/scripts/roles/grant-default-admin.ts \
  --network fraxtal_mainnet \
  --manifest manifests/fraxtal-mainnet-roles.json \
  --dry-run \
  --json-output reports/roles/fraxtal-grant-default-admin-dry-run.json
```

## Operational Note

Fraxtal governance defaults intentionally target the Safe for this migration. The timelock is recorded in the manifest for scan awareness but is not the current migration target.

The fixed grant script now checks that exact Safe target. Current dry-run shows the deployer cannot grant remaining DEFAULT_ADMIN_ROLE entries to the Safe; this is separate from the `TreasuryProxy` proxy-admin transfer path.